### PR TITLE
Fixes Cassandra, which didn't link when raw spans lacked timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Note that Zipkin Dependencies requires minimum JRE 7. For example:
 
 ```bash
 $ wget -O zipkin-dependencies.jar 'https://search.maven.org/remote_content?g=io.zipkin.dependencies&a=zipkin-dependencies&v=LATEST'
-STORAGE_TYPE=cassandra java -jar zipkin-dependencies.jar
+$ STORAGE_TYPE=cassandra java -jar zipkin-dependencies.jar
 ```
 
 You can also start Zipkin Dependencies via [Docker](https://github.com/openzipkin/docker-zipkin-dependencies).

--- a/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
+++ b/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
@@ -17,10 +17,23 @@ import com.google.common.util.concurrent.Futures;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.DependencyLink;
+import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.dependencies.cassandra.CassandraDependenciesJob;
+import zipkin.internal.ApplyTimestampAndDuration;
+import zipkin.internal.MergeById;
 import zipkin.internal.Util;
 import zipkin.storage.DependenciesTest;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.Constants.CLIENT_RECV;
+import static zipkin.Constants.CLIENT_SEND;
+import static zipkin.Constants.SERVER_RECV;
+import static zipkin.Constants.SERVER_SEND;
 
 public class CassandraDependenciesTest extends DependenciesTest {
   private final CassandraStorage storage;
@@ -42,6 +55,9 @@ public class CassandraDependenciesTest extends DependenciesTest {
    */
   @Override
   public void processDependencies(List<Span> spans) {
+    // This gets or derives a timestamp from the spans
+    spans = MergeById.apply(spans);
+
     Futures.getUnchecked(storage.guavaSpanConsumer().accept(spans));
 
     Set<Long> days = new LinkedHashSet<>();
@@ -51,5 +67,50 @@ public class CassandraDependenciesTest extends DependenciesTest {
     for (long day : days) {
       CassandraDependenciesJob.builder().keyspace(storage.keyspace).day(day).build().run();
     }
+  }
+
+  // TODO: remove when zipkin 1.6.1 is out
+  /**
+   * Legacy instrumentation don't set Span.timestamp or duration. Make sure dependencies still
+   * work.
+   */
+  @Test
+  public void getDependencies_noTimestamps() {
+    Endpoint one = Endpoint.create("trace-producer-one", 127 << 24 | 1, 9410);
+    Endpoint onePort3001 = one.toBuilder().port((short) 3001).build();
+    Endpoint two = Endpoint.create("trace-producer-two", 127 << 24 | 2, 9410);
+    Endpoint twoPort3002 = two.toBuilder().port((short) 3002).build();
+    Endpoint three = Endpoint.create("trace-producer-three", 127 << 24 | 3, 9410);
+
+    List<Span> trace = asList(
+        Span.builder().traceId(10L).id(10L).name("get")
+            .addAnnotation(Annotation.create(1445136539256150L, SERVER_RECV, one))
+            .addAnnotation(Annotation.create(1445136540408729L, SERVER_SEND, one))
+            .build(),
+        Span.builder().traceId(10L).parentId(10L).id(20L).name("get")
+            .addAnnotation(Annotation.create(1445136539764798L, CLIENT_SEND, onePort3001))
+            .addAnnotation(Annotation.create(1445136539816432L, SERVER_RECV, two))
+            .addAnnotation(Annotation.create(1445136540401414L, SERVER_SEND, two))
+            .addAnnotation(Annotation.create(1445136540404135L, CLIENT_RECV, onePort3001))
+            .build(),
+        Span.builder().traceId(10L).parentId(20L).id(30L).name("get")
+            .addAnnotation(Annotation.create(1445136540025751L, CLIENT_SEND, twoPort3002))
+            .addAnnotation(Annotation.create(1445136540072846L, SERVER_RECV, three))
+            .addAnnotation(Annotation.create(1445136540394644L, SERVER_SEND, three))
+            .addAnnotation(Annotation.create(1445136540397049L, CLIENT_RECV, twoPort3002))
+            .build()
+    );
+    processDependencies(trace);
+
+    long traceDuration = ApplyTimestampAndDuration.apply(trace.get(0)).duration;
+
+    assertThat(
+        storage.spanStore()
+            .getDependencies((trace.get(0).annotations.get(0).timestamp + traceDuration) / 1000,
+                traceDuration / 1000)
+    ).containsOnly(
+        DependencyLink.create("trace-producer-one", "trace-producer-two", 1),
+        DependencyLink.create("trace-producer-two", "trace-producer-three", 1)
+    );
   }
 }

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import zipkin.Span;
 import zipkin.dependencies.elasticsearch.ElasticsearchDependenciesJob;
+import zipkin.internal.MergeById;
 import zipkin.internal.Util;
 import zipkin.storage.DependenciesTest;
 
@@ -44,6 +45,9 @@ public class ElasticsearchDependenciesTest extends DependenciesTest {
    */
   @Override
   public void processDependencies(List<Span> spans) {
+    // This gets or derives a timestamp from the spans
+    spans = MergeById.apply(spans);
+
     Futures.getUnchecked(storage.guavaSpanConsumer().accept(spans));
 
     Set<Long> days = new LinkedHashSet<>();

--- a/main/src/test/java/zipkin/dependencies/ZipkinDependenciesJobTest.java
+++ b/main/src/test/java/zipkin/dependencies/ZipkinDependenciesJobTest.java
@@ -15,6 +15,7 @@ package zipkin.dependencies;
 
 import java.text.ParseException;
 import java.util.Date;
+import java.util.TimeZone;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -28,6 +29,9 @@ public class ZipkinDependenciesJobTest {
 
   @Test
   public void parseDate() throws ParseException {
+    // Date assertions don't assume UTC
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
     long date = ZipkinDependenciesJob.parseDay("2013-05-15");
     assertThat(new Date(date))
         .hasYear(2013)

--- a/mysql/src/test/java/zipkin/storage/mysql/MySQLDependenciesTest.java
+++ b/mysql/src/test/java/zipkin/storage/mysql/MySQLDependenciesTest.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import zipkin.Span;
 import zipkin.dependencies.mysql.MySQLDependenciesJob;
 import zipkin.internal.CallbackCaptor;
+import zipkin.internal.MergeById;
 import zipkin.internal.Util;
 import zipkin.storage.DependenciesTest;
 
@@ -42,6 +43,9 @@ public class MySQLDependenciesTest extends DependenciesTest {
    */
   @Override
   public void processDependencies(List<Span> spans) {
+    // This gets or derives a timestamp from the spans
+    spans = MergeById.apply(spans);
+
     CallbackCaptor<Void> captor = new CallbackCaptor<>();
     storage().asyncSpanConsumer().accept(spans, captor);
     captor.get(); // block on result


### PR DESCRIPTION
See https://github.com/openzipkin/zipkin/pull/1217
See https://github.com/openzipkin/zipkin-js/issues/29
See https://github.com/openzipkin/zipkin-finagle/issues/10