### PR TITLE
Updates to latest Zipkin and skips Cassandra row on parse error

### DIFF
--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchDependenciesTest.java
@@ -14,6 +14,7 @@
 package zipkin.storage.elasticsearch;
 
 import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +37,7 @@ public class ElasticsearchDependenciesTest extends DependenciesTest {
     return storage;
   }
 
-  @Override public void clear() {
+  @Override public void clear() throws IOException {
     storage.clear();
   }
 

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/ElasticsearchTestGraph.java
@@ -22,16 +22,14 @@ enum ElasticsearchTestGraph {
 
   final String index = "test_zipkin";
 
-  static {
-    ElasticsearchStorage.FLUSH_ON_WRITES = true;
-  }
-
   final LazyCloseable<ElasticsearchStorage> storage = new LazyCloseable<ElasticsearchStorage>() {
     public AssumptionViolatedException ex;
 
     @Override protected ElasticsearchStorage compute() {
       if (ex != null) throw ex;
-      ElasticsearchStorage result = new ElasticsearchStorage.Builder().index(index).build();
+      ElasticsearchStorage result = ElasticsearchStorage.builder()
+          .flushOnWrites(true)
+          .index(index).build();
       CheckResult check = result.check();
       if (check.ok) return result;
       throw ex = new AssumptionViolatedException(check.exception.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>1.6.2</spark.version>
-    <zipkin.version>1.11.0</zipkin.version>
+    <zipkin.version>1.12.1</zipkin.version>
     <logback.version>1.1.7</logback.version>
     <junit.version>4.12</junit.version>
     <assertj.version>3.5.1</assertj.version>


### PR DESCRIPTION
This makes it possible to troubleshoot bad data in cassandra by logging
the lookup keys on the row that failed to parse.

Currently, there's no way to unit test this, so I created a malformed
span and tested manually.

```
17:08:25.628 [Executor task launch worker-0] WARN  z.d.c.CassandraDependenciesJob - Unable to decode span from traces where trace_id=-3823313327434446729 and ts=1475542133045 and span_name='-2048755551635407690_1508523804_-73907135'
java.lang.IllegalArgumentException: Malformed reading Span from TBinary:
	at zipkin.internal.ThriftCodec.exceptionReading(ThriftCodec.java:567)
--snip--
```

Fixes #46