### PR TITLE
Downgrades to scala 2.10 as that's what's used in the Spark 1.6.2 dist

### DIFF
--- a/cassandra/src/main/java/zipkin/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/cassandra/src/main/java/zipkin/dependencies/cassandra/CassandraDependenciesJob.java
@@ -132,7 +132,7 @@ public final class CassandraDependenciesJob {
     List<DependencyLink> links = javaFunctions(sc).cassandraTable(keyspace, "traces")
         .spanBy(r -> r.getLong("trace_id"), Long.class)
         .flatMap(pair -> toLinks(microsLower, microsUpper, pair._2))
-        .mapToPair(link -> Tuple2.apply(Tuple2.apply(link.parent, link.child), link))
+        .mapToPair(link -> tuple2(tuple2(link.parent, link.child), link))
         .reduceByKey((l, r) -> DependencyLink.create(l.parent, l.child, l.callCount + r.callCount))
         .values().collect();
 
@@ -204,5 +204,10 @@ public final class CassandraDependenciesJob {
       ports.add(parsed.getPortOrDefault(9042));
     }
     return ports.size() == 1 ? String.valueOf(ports.iterator().next()) : "9042";
+  }
+
+  /** Added so the code is compilable against scala 2.10 (used in spark 1.6.2) */
+  private static <T1, T2> Tuple2<T1, T2> tuple2(T1 v1, T2 v2) {
+    return new Tuple2<>(v1, v2); // in scala 2.11+ Tuple.apply works naturally
   }
 }

--- a/cassandra/src/main/java/zipkin/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/cassandra/src/main/java/zipkin/dependencies/cassandra/CassandraDependenciesJob.java
@@ -72,9 +72,17 @@ public final class CassandraDependenciesJob {
 
     // local[*] master lets us run & test the job locally without setting a Spark cluster
     String sparkMaster = getEnv("SPARK_MASTER", "local[*]");
+    // needed when not in local mode
+    String[] jars;
 
     // By default the job only works on traces whose first timestamp is today
     long day = midnightUTC(System.currentTimeMillis());
+
+    /** When set, this indicates which jars to distribute to the cluster. */
+    public Builder jars(String... jars) {
+      this.jars = jars;
+      return this;
+    }
 
     /** Keyspace to store dependency rowsToLinks. Defaults to "zipkin" */
     public Builder keyspace(String keyspace) {
@@ -115,6 +123,7 @@ public final class CassandraDependenciesJob {
     this.conf = new SparkConf(true)
         .setMaster(builder.sparkMaster)
         .setAppName(getClass().getName());
+    if (builder.jars != null) conf.setJars(builder.jars);
     for (Map.Entry<String, String> entry : builder.sparkProperties.entrySet()) {
       conf.set(entry.getKey(), entry.getValue());
     }

--- a/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
@@ -62,9 +62,17 @@ public final class ElasticsearchDependenciesJob {
 
     // local[*] master lets us run & test the job locally without setting a Spark cluster
     String sparkMaster = getEnv("SPARK_MASTER", "local[*]");
+    // needed when not in local mode
+    String[] jars;
 
     // By default the job only works on traces whose first timestamp is today
     long day = midnightUTC(System.currentTimeMillis());
+
+    /** When set, this indicates which jars to distribute to the cluster. */
+    public Builder jars(String... jars) {
+      this.jars = jars;
+      return this;
+    }
 
     /** The index prefix to use when generating daily index names. Defaults to "zipkin" */
     public Builder index(String index) {
@@ -100,6 +108,7 @@ public final class ElasticsearchDependenciesJob {
     this.conf = new SparkConf(true)
         .setMaster(builder.sparkMaster)
         .setAppName(getClass().getName());
+    if (builder.jars != null) conf.setJars(builder.jars);
     for (Map.Entry<String, String> entry : builder.sparkProperties.entrySet()) {
       conf.set(entry.getKey(), entry.getValue());
     }

--- a/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
@@ -114,7 +114,7 @@ public final class ElasticsearchDependenciesJob {
     JavaRDD<Map<String, Object>> links = JavaEsSpark.esJsonRDD(sc, bucket + "/span")
         .groupBy(pair -> traceId(pair._2))
         .flatMap(pair -> toLinks(pair._2))
-        .mapToPair(link -> Tuple2.apply(Tuple2.apply(link.parent, link.child), link))
+        .mapToPair(link -> tuple2(tuple2(link.parent, link.child), link))
         .reduceByKey((l, r) -> DependencyLink.create(l.parent, l.child, l.callCount + r.callCount))
         .values()
         .map(l -> ImmutableMap.<String, Object>of(
@@ -161,5 +161,10 @@ public final class ElasticsearchDependenciesJob {
       }
     }
     throw new MalformedJsonException("no traceId in " + json);
+  }
+
+  /** Added so the code is compilable against scala 2.10 (used in spark 1.6.2) */
+  private static <T1, T2> Tuple2<T1, T2> tuple2(T1 v1, T2 v2) {
+    return new Tuple2<>(v1, v2); // in scala 2.11+ Tuple.apply works naturally
   }
 }

--- a/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
+++ b/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
@@ -57,9 +57,17 @@ public final class MySQLDependenciesJob {
 
     // local[*] master lets us run & test the job locally without setting a Spark cluster
     String sparkMaster = getEnv("SPARK_MASTER", "local[*]");
+    // needed when not in local mode
+    String[] jars;
 
     // By default the job only works on traces whose first timestamp is today
     long day = midnightUTC(System.currentTimeMillis());
+
+    /** When set, this indicates which jars to distribute to the cluster. */
+    public Builder jars(String... jars) {
+      this.jars = jars;
+      return this;
+    }
 
     /** The database to use. Defaults to "zipkin" */
     public Builder db(String db) {
@@ -144,6 +152,7 @@ public final class MySQLDependenciesJob {
     this.conf = new SparkConf(true)
         .setMaster(builder.sparkMaster)
         .setAppName(getClass().getName());
+    if (builder.jars != null) conf.setJars(builder.jars);
     for (Map.Entry<String, String> entry : builder.sparkProperties.entrySet()) {
       conf.set(entry.getKey(), entry.getValue());
     }

--- a/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
+++ b/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
@@ -183,7 +183,7 @@ public final class MySQLDependenciesJob {
           return linker.link();
         })
         .values()
-        .mapToPair(link -> Tuple2.apply(Tuple2.apply(link.parent, link.child), link))
+        .mapToPair(link -> tuple2(tuple2(link.parent, link.child), link))
         .reduceByKey((l, r) -> DependencyLink.create(l.parent, l.child, l.callCount + r.callCount))
         .values().collect();
 
@@ -212,5 +212,10 @@ public final class MySQLDependenciesJob {
   private static String getEnv(String key, String defaultValue) {
     String result = System.getenv(key);
     return result != null ? result : defaultValue;
+  }
+
+  /** Added so the code is compilable against scala 2.10 (used in spark 1.6.2) */
+  private static <T1, T2> Tuple2<T1, T2> tuple2(T1 v1, T2 v2) {
+    return new Tuple2<>(v1, v2); // in scala 2.11+ Tuple.apply works naturally
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <main.basedir>${project.basedir}</main.basedir>
 
-    <scala.binary.version>2.11</scala.binary.version>
+    <scala.binary.version>2.10</scala.binary.version>
     <spark.version>1.6.2</spark.version>
     <zipkin.version>1.12.1</zipkin.version>
     <logback.version>1.1.7</logback.version>


### PR DESCRIPTION
@tramchamploo noticed that we don't operate against the normal Spark 1.6.2 build