### PR TITLE
Supports 128-bit trace aggregation and Elasticsearch 5.0

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <spark-cassandra-connector.version>1.6.0</spark-cassandra-connector.version>
+    <spark-cassandra-connector.version>1.6.2</spark-cassandra-connector.version>
   </properties>
 
   <dependencies>
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>com.datastax.spark</groupId>
-      <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
+      <artifactId>spark-cassandra-connector-unshaded_${scala.binary.version}</artifactId>
       <version>${spark-cassandra-connector.version}</version>
     </dependency>
 

--- a/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
+++ b/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
@@ -17,23 +17,11 @@ import com.google.common.util.concurrent.Futures;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Test;
-import zipkin.Annotation;
-import zipkin.DependencyLink;
-import zipkin.Endpoint;
 import zipkin.Span;
 import zipkin.dependencies.cassandra.CassandraDependenciesJob;
-import zipkin.internal.ApplyTimestampAndDuration;
 import zipkin.internal.MergeById;
 import zipkin.internal.Util;
 import zipkin.storage.DependenciesTest;
-
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin.Constants.CLIENT_RECV;
-import static zipkin.Constants.CLIENT_SEND;
-import static zipkin.Constants.SERVER_RECV;
-import static zipkin.Constants.SERVER_SEND;
 
 public class CassandraDependenciesTest extends DependenciesTest {
   private final CassandraStorage storage;
@@ -67,50 +55,5 @@ public class CassandraDependenciesTest extends DependenciesTest {
     for (long day : days) {
       CassandraDependenciesJob.builder().keyspace(storage.keyspace).day(day).build().run();
     }
-  }
-
-  // TODO: remove when zipkin 1.6.1 is out
-  /**
-   * Legacy instrumentation don't set Span.timestamp or duration. Make sure dependencies still
-   * work.
-   */
-  @Test
-  public void getDependencies_noTimestamps() {
-    Endpoint one = Endpoint.create("trace-producer-one", 127 << 24 | 1, 9410);
-    Endpoint onePort3001 = one.toBuilder().port((short) 3001).build();
-    Endpoint two = Endpoint.create("trace-producer-two", 127 << 24 | 2, 9410);
-    Endpoint twoPort3002 = two.toBuilder().port((short) 3002).build();
-    Endpoint three = Endpoint.create("trace-producer-three", 127 << 24 | 3, 9410);
-
-    List<Span> trace = asList(
-        Span.builder().traceId(10L).id(10L).name("get")
-            .addAnnotation(Annotation.create(1445136539256150L, SERVER_RECV, one))
-            .addAnnotation(Annotation.create(1445136540408729L, SERVER_SEND, one))
-            .build(),
-        Span.builder().traceId(10L).parentId(10L).id(20L).name("get")
-            .addAnnotation(Annotation.create(1445136539764798L, CLIENT_SEND, onePort3001))
-            .addAnnotation(Annotation.create(1445136539816432L, SERVER_RECV, two))
-            .addAnnotation(Annotation.create(1445136540401414L, SERVER_SEND, two))
-            .addAnnotation(Annotation.create(1445136540404135L, CLIENT_RECV, onePort3001))
-            .build(),
-        Span.builder().traceId(10L).parentId(20L).id(30L).name("get")
-            .addAnnotation(Annotation.create(1445136540025751L, CLIENT_SEND, twoPort3002))
-            .addAnnotation(Annotation.create(1445136540072846L, SERVER_RECV, three))
-            .addAnnotation(Annotation.create(1445136540394644L, SERVER_SEND, three))
-            .addAnnotation(Annotation.create(1445136540397049L, CLIENT_RECV, twoPort3002))
-            .build()
-    );
-    processDependencies(trace);
-
-    long traceDuration = ApplyTimestampAndDuration.apply(trace.get(0)).duration;
-
-    assertThat(
-        storage.spanStore()
-            .getDependencies((trace.get(0).annotations.get(0).timestamp + traceDuration) / 1000,
-                traceDuration / 1000)
-    ).containsOnly(
-        DependencyLink.create("trace-producer-one", "trace-producer-two", 1),
-        DependencyLink.create("trace-producer-two", "trace-producer-three", 1)
-    );
   }
 }

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -28,20 +28,27 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <elasticsearch.version>2.3.3</elasticsearch.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch-spark_${scala.binary.version}</artifactId>
-      <version>${elasticsearch.version}</version>
+      <artifactId>elasticsearch-spark-13_${scala.binary.version}</artifactId>
+      <version>5.0.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.zipkin.java</groupId>
-      <artifactId>zipkin-storage-elasticsearch</artifactId>
+      <artifactId>zipkin-storage-elasticsearch-http</artifactId>
       <version>${zipkin.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Transitive dependency for zipkin-storage-elasticsearch-http -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.8.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -126,8 +126,8 @@
                   </includes>
                 </filter>
                 <filter>
-                  <!-- org.elasticsearch.spark.sql.DefaultSource15 -->
-                  <artifact>org.elasticsearch:elasticsearch-spark_${scala.binary.version}</artifact>
+                  <!-- org.elasticsearch.spark.sql.SparkSQLCompatibilityLevel -->
+                  <artifact>org.elasticsearch:elasticsearch-spark-13_${scala.binary.version}</artifact>
                   <includes>
                     <include>**</include>
                   </includes>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -33,7 +33,7 @@
 
          MariaDB has a friendlier license, LGPL, which is less scary in audits.
     -->
-    <mariadb-java-client.version>1.4.6</mariadb-java-client.version>
+    <mariadb-java-client.version>1.5.5</mariadb-java-client.version>
   </properties>
 
   <dependencies>

--- a/mysql/src/main/java/zipkin/dependencies/mysql/DependencyLinkSpanIterator.java
+++ b/mysql/src/main/java/zipkin/dependencies/mysql/DependencyLinkSpanIterator.java
@@ -16,6 +16,7 @@ package zipkin.dependencies.mysql;
 import java.util.Iterator;
 import org.apache.spark.sql.Row;
 import zipkin.internal.DependencyLinkSpan;
+import zipkin.internal.Nullable;
 import zipkin.internal.PeekingIterator;
 
 import static zipkin.Constants.CLIENT_ADDR;
@@ -23,18 +24,62 @@ import static zipkin.Constants.CLIENT_SEND;
 import static zipkin.Constants.SERVER_ADDR;
 import static zipkin.Constants.SERVER_RECV;
 
-/** Processes rows are in the same trace and ordered by span id */
+/**
+ * Convenience that lazy converts rows into {@linkplain DependencyLinkSpan} objects.
+ *
+ * <p>Out-of-date schemas may be missing the trace_id_high field. When present, this becomes {@link
+ * DependencyLinkSpan.TraceId#hi} used as the left-most 16 characters of the traceId in logging
+ * statements.
+ */
 final class DependencyLinkSpanIterator implements Iterator<DependencyLinkSpan> {
 
-  final PeekingIterator<Row> delegate;
+  /** Assumes the input records are sorted by trace id, span id */
+  static final class ByTraceId implements Iterator<Iterator<DependencyLinkSpan>> {
+    final PeekingIterator<Row> delegate;
+    final boolean hasTraceIdHigh;
+    final int traceIdIndex;
 
-  DependencyLinkSpanIterator(Iterator<Row> delegate) {
-    this.delegate = new PeekingIterator<>(delegate);
+    @Nullable Long currentTraceIdHi;
+    long currentTraceIdLo;
+
+    ByTraceId(Iterator<Row> delegate, boolean hasTraceIdHigh) {
+      this.delegate = new PeekingIterator<>(delegate);
+      this.hasTraceIdHigh = hasTraceIdHigh;
+      this.traceIdIndex = hasTraceIdHigh ? 1 : 0;
+    }
+
+    @Override public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override public Iterator<DependencyLinkSpan> next() {
+      currentTraceIdHi = hasTraceIdHigh ? delegate.peek().getLong(0) : null;
+      currentTraceIdLo = delegate.peek().getLong(traceIdIndex);
+      return new DependencyLinkSpanIterator(delegate, currentTraceIdHi, currentTraceIdLo);
+    }
+
+    @Override public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  final PeekingIterator<Row> delegate;
+  final int traceIdIndex;
+  @Nullable final Long traceIdHi;
+  final long traceIdLo;
+
+  DependencyLinkSpanIterator(PeekingIterator<Row> delegate, Long traceIdHi, long traceIdLo) {
+    this.delegate = delegate;
+    this.traceIdIndex = traceIdHi != null ? 1 : 0;
+    this.traceIdHi = traceIdHi;
+    this.traceIdLo = traceIdLo;
   }
 
   @Override
   public boolean hasNext() {
-    return delegate.hasNext();
+    return delegate.hasNext()
+        && (traceIdHi == null || traceIdHi.equals(delegate.peek().getLong(0)))
+        && delegate.peek().getLong(traceIdIndex) == traceIdLo; // trace_id
   }
 
   @Override
@@ -42,10 +87,10 @@ final class DependencyLinkSpanIterator implements Iterator<DependencyLinkSpan> {
     Row row = delegate.next();
 
     DependencyLinkSpan.Builder result = DependencyLinkSpan.builder(
-        0, // trace_id_high: ignoring for now
-        row.getLong(0), // trace_id
-        row.isNullAt(1) ? null : row.getLong(1), // parent_id
-        row.getLong(2) // id
+        traceIdHi != null ? traceIdHi : 0L,
+        traceIdLo,
+        row.isNullAt(traceIdIndex + 1) ? null : row.getLong(traceIdIndex + 1), // parent_id
+        row.getLong(traceIdIndex + 2) // id
     );
     parseClientAndServerNames(result, row);
 
@@ -54,7 +99,7 @@ final class DependencyLinkSpanIterator implements Iterator<DependencyLinkSpan> {
       if (next == null) {
         continue;
       }
-      if (row.getLong(2) == next.getLong(2)) { // id
+      if (row.getLong(traceIdIndex + 2) == next.getLong(traceIdIndex + 2)) { // id
         delegate.next(); // advance the iterator since we are in the same span id
         parseClientAndServerNames(result, next);
       } else {
@@ -65,8 +110,8 @@ final class DependencyLinkSpanIterator implements Iterator<DependencyLinkSpan> {
   }
 
   void parseClientAndServerNames(DependencyLinkSpan.Builder span, Row row) {
-    String key = row.getString(3); // a_key
-    String serviceName = row.getString(4); // a_service_name
+    String key = row.getString(traceIdIndex + 3); // a_key
+    String serviceName = row.getString(traceIdIndex + 4); // a_service_name
 
     if (key == null) return; // neither client nor server (usually local)
     switch (key) {

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <scala.binary.version>2.10</scala.binary.version>
-    <spark.version>1.6.2</spark.version>
-    <zipkin.version>1.14.1</zipkin.version>
+    <spark.version>1.6.3</spark.version>
+    <zipkin.version>1.16.0</zipkin.version>
     <logback.version>1.1.7</logback.version>
     <junit.version>4.12</junit.version>
     <assertj.version>3.5.1</assertj.version>


### PR DESCRIPTION
This updates to latest zipkin to support aggregation when 128-bit trace
IDs are in use. It also tests against Elasticsearch 5.0.