### PR TITLE
Validating the Span ID.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,9 @@ before_install:
 
 install:
   # Override default travis to use the maven wrapper
+  # Use quiet as shade plugin creates too many logs for Travis: The log length has exceeded the limit of 4 MB
   # skip license on travis due to zipkin #1512
-  - ./mvnw -q install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dlicense.skip=true
+  - ./mvnw -q install -DskipTests=true -Dmaven.javadoc.skip=true -Dlicense.skip=true -B -V
 
 script:
   - ./travis/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Use a bigger VM
+sudo: required
 dist: trusty
 addons:
   apt:

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -111,7 +111,7 @@ fi
 
 # Use quiet as shade plugin creates too many logs for Travis: The log length has exceeded the limit of 4 MB
 # skip license on travis due to zipkin #1512
-MYSQL_USER=root ./mvnw -q install -nsu -Dlicense.skip=true
+MYSQL_USER=root ./mvnw -q install -Dlicense.skip=true -nsu
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
 if is_pull_request; then
@@ -119,8 +119,7 @@ if is_pull_request; then
 # If we are on master, we will deploy the latest snapshot or release version
 #   - If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
 elif is_travis_branch_master; then
-  # skip license on travis due to zipkin #1512
-  ./mvnw -q --batch-mode -s ./.settings.xml -Prelease -nsu -Darguments="-DskipTests -Dlicense.skip=true" deploy
+  ./mvnw -q --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 
   # If the deployment succeeded, sync it to Maven Central. Note: this needs to be done once per project, not module, hence -N
   if is_release_commit; then
@@ -130,6 +129,8 @@ elif is_travis_branch_master; then
 # If we are on a release tag, the following will update any version references and push a version tag for deployment.
 elif build_started_by_tag; then
   safe_checkout_master
-  ./mvnw -q --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
+  # Use quiet as shade plugin creates too many logs for Travis: The log length has exceeded the limit of 4 MB
+  # skip license on travis due to #1512
+  ./mvnw -q --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests -Dlicense.skip=true" release:prepare
 fi
 


### PR DESCRIPTION
Considering the example where the we have a dependencies from M1--> M2 -->M3
M1-->M3 dependency should only be defined , when  we have M1 directly calling M3.
Currently for our case we have got the API-Gateway as entry point , which in turn invoke the central service, which in turn route the request to other services.

AG-->CS-->(M1,M2,M3)

Valid dependencies in the system are.

AG-->CS-->(M3)
AG-->CS-->(M1)
AG-->CS-->(M2)

Whereas below created dependency are invalid.
AG-->(M1)
AG-->(M2)

Reason why we coudl have above incorrect dependency could be many reason.

1) CS span gets dropped out: In that case M1,M2 would have CS span id as their parent span id in the JSON record, which would not exist in the zipkin database, While defining the dependencies we need to validate whether all such dependent span id exist, if they don't exist then ignore that span record for dependency calculation.


