### PR TITLE
Upgrades to Spark 2.1

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <spark-cassandra-connector.version>1.6.7</spark-cassandra-connector.version>
+    <spark-cassandra-connector.version>2.0.3</spark-cassandra-connector.version>
   </properties>
 
   <dependencies>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -33,8 +33,8 @@
   <dependencies>
     <dependency>
       <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch-spark-13_${scala.binary.version}</artifactId>
-      <version>5.5.0</version>
+      <artifactId>elasticsearch-spark-20_${scala.binary.version}</artifactId>
+      <version>5.5.1</version>
     </dependency>
 
     <dependency>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -116,7 +116,7 @@
                 </filter>
                 <filter>
                   <!-- org.elasticsearch.spark.sql.SparkSQLCompatibilityLevel -->
-                  <artifact>org.elasticsearch:elasticsearch-spark-13_${scala.binary.version}</artifact>
+                  <artifact>org.elasticsearch:elasticsearch-spark-20_${scala.binary.version}</artifact>
                   <includes>
                     <include>**</include>
                   </includes>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -33,7 +33,7 @@
 
          MariaDB has a friendlier license, LGPL, which is less scary in audits.
     -->
-    <mariadb-java-client.version>1.6.2</mariadb-java-client.version>
+    <mariadb-java-client.version>1.6.3</mariadb-java-client.version>
   </properties>
 
   <dependencies>

--- a/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
+++ b/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.execution.datasources.jdbc.DefaultSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;
@@ -199,8 +198,7 @@ public final class MySQLDependenciesJob {
 
     JavaSparkContext sc = new JavaSparkContext(conf);
 
-    List<DependencyLink> links = new SQLContext(sc).read().format(DefaultSource.class.getName())
-        .options(options).load()
+    List<DependencyLink> links = new SQLContext(sc).read().format("jdbc").options(options).load()
         .toJavaRDD()
         .groupBy(r -> r.getLong(hasTraceIdHigh ? 1 : 0) /* trace_id */)
         .flatMapValues(new RowsToDependencyLinks(logInitializer, hasTraceIdHigh))

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,10 @@
 
     <main.basedir>${project.basedir}</main.basedir>
 
-    <scala.binary.version>2.10</scala.binary.version>
-    <spark.version>1.6.3</spark.version>
-    <zipkin.version>1.28.0</zipkin.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <!-- spark-cassandra-connector doesn't yet support spark 2.2 -->
+    <spark.version>2.1.1</spark.version>
+    <zipkin.version>1.28.1</zipkin.version>
     <junit.version>4.12</junit.version>
     <assertj.version>3.8.0</assertj.version>
 


### PR DESCRIPTION
We can't go Spark 2.2, yet, as cassandra doesn't support it.

Fixes #77