### PR TITLE
Fixes shade configuration

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -109,6 +109,12 @@
                   </includes>
                 </filter>
                 <filter>
+                  <artifact>net.jpountz.lz4:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
                   <artifact>com.typesafe.akka:*</artifact>
                   <includes>
                     <include>**</include>

--- a/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
+++ b/mysql/src/main/java/zipkin/dependencies/mysql/MySQLDependenciesJob.java
@@ -199,7 +199,10 @@ public final class MySQLDependenciesJob {
 
     JavaSparkContext sc = new JavaSparkContext(conf);
 
-    List<DependencyLink> links = new SQLContext(sc).read().format("jdbc").options(options).load()
+    List<DependencyLink> links = new SQLContext(sc).read()
+        .format("org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider")
+        .options(options)
+        .load()
         .toJavaRDD()
         .groupBy(r -> r.getLong(hasTraceIdHigh ? 1 : 0) /* trace_id */)
         .flatMapValues(new RowsToDependencyLinks(logInitializer, hasTraceIdHigh))


### PR DESCRIPTION
tested on all three storage types via docker:

```bash
$ STORAGE_TYPE=mysql MYSQL_USER=zipkin MYSQL_PASS=zipkin MYSQL_HOST=192.168.99.100 java -jar ./main/target/zipkin-dependencies-1.7.1-SNAPSHOT.jar
$ STORAGE_TYPE=elasticsearch ES_HOSTS=192.168.99.100 ES_NODES_WAN_ONLY=true java -jar ./main/target/zipkin-dependencies-1.7.1-SNAPSHOT.jar
$ STORAGE_TYPE=cassandra CASSANDRA_CONTACT_POINTS=192.168.99.100 java -jar ./main/target/zipkin-dependencies-1.7.1-SNAPSHOT.jar
```