### PR TITLE
Add support for configuring Elasticsearch username, password, and TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Elasticsearch is used when `STORAGE_TYPE=elasticsearch`. The schema is compatibl
                   recommended to set this to all the master nodes of the cluster.
     * `ES_NODES_WAN_ONLY`: Set to true to only use the values set in ES_HOSTS, for example if your
                            elasticsearch cluster is in Docker. Defaults to false
+    * `ES_USERNAME` and `ES_PASSWORD`: Elasticsearch basic authentication. Use when X-Pack security
+                                       (formerly Shield) is in place. By default no username or
+                                       password is provided to elasticsearch.
+    * `ES_SSL`: Set to `true` when connections to elasticsearch must use TLS/SSL. Defaults to `false`.
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Elasticsearch is used when `STORAGE_TYPE=elasticsearch`. The schema is compatibl
     * `ES_HOSTS`: A comma separated list of elasticsearch hosts advertising http. Defaults to
                   localhost. Add port section if not listening on port 9200. Only one of these hosts
                   needs to be available to fetch the remaining nodes in the cluster. It is
-                  recommended to set this to all the master nodes of the cluster.
+                  recommended to set this to all the master nodes of the cluster. Use url format for
+                  SSL. For example, "https://yourhost:8888"
     * `ES_NODES_WAN_ONLY`: Set to true to only use the values set in ES_HOSTS, for example if your
                            elasticsearch cluster is in Docker. Defaults to false
     * `ES_USERNAME` and `ES_PASSWORD`: Elasticsearch basic authentication. Use when X-Pack security
                                        (formerly Shield) is in place. By default no username or
                                        password is provided to elasticsearch.
-    * `ES_SSL`: Set to `true` when connections to elasticsearch must use TLS/SSL. Defaults to `false`.
 
 Example usage:
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -49,8 +49,13 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <!-- keep this in sync with zipkin's version -->
-      <version>3.8.1</version>
+      <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
@@ -61,6 +61,14 @@ public final class ElasticsearchDependenciesJob {
       sparkProperties.put("es.nodes.wan.only", getEnv("ES_NODES_WAN_ONLY", "false"));
       // NOTE: unlike zipkin, this uses the http port
       sparkProperties.put("es.nodes", getEnv("ES_HOSTS", "127.0.0.1"));
+      final String username = getEnv("ES_USERNAME", null);
+      if (username != null && !username.trim().isEmpty()) {
+        sparkProperties.put("es.net.http.auth.user", username);
+      }
+      final String password = getEnv("ES_PASSWORD", null);
+      if (password != null && !password.trim().isEmpty()) {
+        sparkProperties.put("es.net.http.auth.pass", password);
+      }
     }
 
     // local[*] master lets us run & test the job locally without setting a Spark cluster

--- a/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
@@ -61,6 +61,7 @@ public final class ElasticsearchDependenciesJob {
       sparkProperties.put("es.nodes.wan.only", getEnv("ES_NODES_WAN_ONLY", "false"));
       // NOTE: unlike zipkin, this uses the http port
       sparkProperties.put("es.nodes", getEnv("ES_HOSTS", "127.0.0.1"));
+      sparkProperties.put("es.net.ssl", getEnv("ES_SSL", "false"));
       final String username = getEnv("ES_USERNAME", null);
       if (username != null && !username.trim().isEmpty()) {
         sparkProperties.put("es.net.http.auth.user", username);

--- a/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
@@ -15,6 +15,7 @@ package zipkin.dependencies.elasticsearch;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -51,6 +52,9 @@ public final class ElasticsearchDependenciesJob {
   public static final class Builder {
 
     String index = getEnv("ES_INDEX", "zipkin");
+    String hosts = getEnv("ES_HOSTS", "127.0.0.1");
+    String username = getEnv("ES_USERNAME", null);
+    String password = getEnv("ES_PASSWORD", null);
 
     final Map<String, String> sparkProperties = new LinkedHashMap<>();
 
@@ -59,17 +63,6 @@ public final class ElasticsearchDependenciesJob {
       // don't die if there are no spans
       sparkProperties.put("es.index.read.missing.as.empty", "true");
       sparkProperties.put("es.nodes.wan.only", getEnv("ES_NODES_WAN_ONLY", "false"));
-      // NOTE: unlike zipkin, this uses the http port
-      sparkProperties.put("es.nodes", getEnv("ES_HOSTS", "127.0.0.1"));
-      sparkProperties.put("es.net.ssl", getEnv("ES_SSL", "false"));
-      final String username = getEnv("ES_USERNAME", null);
-      if (username != null && !username.trim().isEmpty()) {
-        sparkProperties.put("es.net.http.auth.user", username);
-      }
-      final String password = getEnv("ES_PASSWORD", null);
-      if (password != null && !password.trim().isEmpty()) {
-        sparkProperties.put("es.net.http.auth.pass", password);
-      }
     }
 
     // local[*] master lets us run & test the job locally without setting a Spark cluster
@@ -93,9 +86,21 @@ public final class ElasticsearchDependenciesJob {
       return this;
     }
 
-    public Builder esNodes(String esNodes) { // visible for testing
-      sparkProperties.put("es.nodes", checkNotNull(esNodes, "esNodes"));
+    public Builder hosts(String hosts) {
+      this.hosts = checkNotNull(hosts, "hosts");
       sparkProperties.put("es.nodes.wan.only", "true");
+      return this;
+    }
+
+    /** username used for basic auth. Needed when Shield or X-Pack security is enabled */
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    /** password used for basic auth. Needed when Shield or X-Pack security is enabled */
+    public Builder password(String password) {
+      this.password = password;
       return this;
     }
 
@@ -133,6 +138,10 @@ public final class ElasticsearchDependenciesJob {
         .setMaster(builder.sparkMaster)
         .setAppName(getClass().getName());
     if (builder.jars != null) conf.setJars(builder.jars);
+    if (builder.username != null) conf.set("es.net.http.auth.user", builder.username);
+    if (builder.password != null) conf.set("es.net.http.auth.pass", builder.password);
+    conf.set("es.nodes", parseHosts(builder.hosts));
+    if (builder.hosts.indexOf("https") != -1) conf.set("es.net.ssl", "true");
     for (Map.Entry<String, String> entry : builder.sparkProperties.entrySet()) {
       conf.set(entry.getKey(), entry.getValue());
     }
@@ -216,7 +225,7 @@ public final class ElasticsearchDependenciesJob {
 
   private static String getEnv(String key, String defaultValue) {
     String result = System.getenv(key);
-    return result != null ? result : defaultValue;
+    return result != null && !result.isEmpty() ? result : defaultValue;
   }
 
   /** returns the lower 64 bits of the trace ID */
@@ -238,5 +247,27 @@ public final class ElasticsearchDependenciesJob {
   /** Added so the code is compilable against scala 2.10 (used in spark 1.6.2) */
   private static <T1, T2> Tuple2<T1, T2> tuple2(T1 v1, T2 v2) {
     return new Tuple2<>(v1, v2); // in scala 2.11+ Tuple.apply works naturally
+  }
+
+  static String parseHosts(String hosts) {
+    StringBuilder to = new StringBuilder();
+    String[] hostParts = hosts.split(",");
+    for (int i = 0; i < hostParts.length; i++) {
+      String host = hostParts[i];
+      if (host.startsWith("http")) {
+        URI httpUri = URI.create(host);
+        int port = httpUri.getPort();
+        if (port == -1) {
+          port = host.startsWith("https") ? 443 : 80;
+        }
+        to.append(httpUri.getHost() + ":" + port);
+      } else {
+        to.append(host);
+      }
+      if (i + 1 < hostParts.length) {
+        to.append(',');
+      }
+    }
+    return to.toString();
   }
 }

--- a/elasticsearch/src/test/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJobTest.java
+++ b/elasticsearch/src/test/java/zipkin/dependencies/elasticsearch/ElasticsearchDependenciesJobTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.dependencies.elasticsearch;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin.dependencies.elasticsearch.ElasticsearchDependenciesJob.parseHosts;
+
+public class ElasticsearchDependenciesJobTest {
+
+  @Test public void buildHttps() {
+    ElasticsearchDependenciesJob job  = ElasticsearchDependenciesJob.builder()
+        .hosts("https://foobar")
+        .build();
+    assertThat(job.conf.get("es.nodes"))
+        .isEqualTo("foobar:443");
+    assertThat(job.conf.get("es.net.ssl"))
+        .isEqualTo("true");
+  }
+
+  @Test public void buildAuth() {
+    ElasticsearchDependenciesJob job  = ElasticsearchDependenciesJob.builder()
+        .username("foo")
+        .password("bar")
+        .build();
+    assertThat(job.conf.get("es.net.http.auth.user"))
+        .isEqualTo("foo");
+    assertThat(job.conf.get("es.net.http.auth.pass"))
+        .isEqualTo("bar");
+  }
+
+  @Test public void parseHosts_default() {
+    assertThat(parseHosts("1.1.1.1"))
+        .isEqualTo("1.1.1.1");
+  }
+
+  @Test public void parseHosts_commaDelimits() {
+    assertThat(parseHosts("1.1.1.1:9200,2.2.2.2:9200"))
+        .isEqualTo("1.1.1.1:9200,2.2.2.2:9200");
+  }
+
+  @Test public void parseHosts_http_defaultPort() {
+    assertThat(parseHosts("http://1.1.1.1"))
+        .isEqualTo("1.1.1.1:80");
+  }
+
+  @Test public void parseHosts_https_defaultPort() {
+    assertThat(parseHosts("https://1.1.1.1"))
+        .isEqualTo("1.1.1.1:443");
+  }
+}

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchDependenciesTest.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchDependenciesTest.java
@@ -52,7 +52,7 @@ abstract class ElasticsearchDependenciesTest extends DependenciesTest {
     }
 
     for (long day : days) {
-      ElasticsearchDependenciesJob.builder().index(INDEX).esNodes(esNodes()).day(day).build().run();
+      ElasticsearchDependenciesJob.builder().index(INDEX).hosts(esNodes()).day(day).build().run();
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
     <junit.version>4.12</junit.version>
     <assertj.version>3.8.0</assertj.version>
     <jackson.version>2.9.0</jackson.version>
+    <!-- keep this in sync with zipkin's version -->
+    <okhttp.version>3.8.1</okhttp.version>
     <testcontainers.version>1.4.1</testcontainers.version>
 
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>


### PR DESCRIPTION
If an Elasticsearch cluster requires TLS connections or user authentication, there is no way to provide the necessary configuration to the Zipkin dependencies job.

These changes add three new environment variables that the Zipkin dependencies job will map to spark job (and ultimately elasticsearch-hadoop) configuration. These environment variables (and the corresponding elasticsearch-hadoop configuration property) are `ES_USERNAME` (`es.net.http.auth.user`), `ES_PASSWORD` (`es.net.http.auth.pass`), and `ES_SSL` (`es.net.ssl`). The default values for username and password are empty. The default value for enabling TLS/SSL is false. These defaults match the defaults for elasticsearch-hadoop, so should maintain current behavior for anyone who has not set these environment variables. Documentation of elasticsearch-hadoop configuration can be found on https://www.elastic.co/guide/en/elasticsearch/hadoop/current/configuration.html.

One open question I have is what tests it makes sense to add for these changes. I attempted to add unit tests to verify that values from the environments variables are mapped to the appropriate spark job config properties. The use of System.getenv() made that difficult without introducing a new test dependency capable of mocking static method calls or doing some really ugly reflection hacking to trick the JVM into thinking environment variables are set that are not (something like https://stackoverflow.com/a/7201825). Any suggestions on the scope or approach to unit tests appropriate for this change are welcome.