### PR TITLE
Adds CASSANDRA_LOCAL_DC for local DC to connect to

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Cassandra is used when `STORAGE_TYPE=cassandra`. The schema is compatible with Z
 
     * `CASSANDRA_KEYSPACE`: The keyspace to use. Defaults to "zipkin".
     * `CASSANDRA_CONTACT_POINTS`: Comma separated list of hosts / ip addresses part of Cassandra cluster. Defaults to localhost
+    * `CASSANDRA_LOCAL_DC`: The local DC to connect to (other nodes will be ignored)
     * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails
     * `CASSANDRA_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
 

--- a/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
+++ b/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
@@ -57,7 +57,10 @@ public class CassandraDependenciesTest extends DependenciesTest {
     }
 
     for (long day : days) {
-      CassandraDependenciesJob.builder().keyspace(storage.keyspace).day(day).build().run();
+      CassandraDependenciesJob.builder()
+          .keyspace(storage.keyspace)
+          .localDc(storage.localDc)
+          .day(day).build().run();
     }
   }
 }

--- a/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
+++ b/cassandra/src/test/java/zipkin/storage/cassandra/CassandraTestGraph.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,7 +25,10 @@ enum CassandraTestGraph {
 
     @Override protected CassandraStorage compute() {
       if (ex != null) throw ex;
-      CassandraStorage result = CassandraStorage.builder().keyspace("test_zipkin").build();
+      CassandraStorage result = CassandraStorage.builder()
+          .keyspace("test_zipkin")
+          .localDc("datacenter1")
+          .build();
       CheckResult check = result.check();
       if (check.ok) return result;
       throw ex = new AssumptionViolatedException(check.exception.getMessage());


### PR DESCRIPTION
CASSANDRA_LOCAL_DC maps directly to connection.local_dc
See https://github.com/datastax/spark-cassandra-connector/blob/master/doc/reference.md#cassandra-connection-parameters

This is similar, but not exactly the same as zipkin storage (because the
latter is using latency-based round robin).