### PR TITLE
Fixes guava conflict w/cassandra by shading the classes

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -115,12 +115,6 @@
                   </includes>
                 </filter>
                 <filter>
-                  <artifact>com.typesafe.akka:*</artifact>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </filter>
-                <filter>
                   <!-- org.elasticsearch.spark.sql.SparkSQLCompatibilityLevel -->
                   <artifact>org.elasticsearch:elasticsearch-spark-20_${scala.binary.version}</artifact>
                   <includes>
@@ -144,6 +138,26 @@
                   </excludes>
                 </filter>
               </filters>
+              <!--
+                com.datastax.driver.core.Cluster fails to initialize (because of its check for 16.01)
+                See https://stackoverflow.com/questions/36877897/detected-guava-issue-1635-which-indicates-that-a-version-of-guava-less-than-16
+                TODO: When cassandra-driver-core 4.x is out, revisit this as it no longer uses guava
+              -->
+              <relocations>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>shaded.com.google.common</shadedPattern>
+                  <includes>
+                    <include>com.google.common.**</include>
+                  </includes>
+
+                  <excludes>
+                    <exclude>com.google.common.base.Optional</exclude>
+                    <exclude>com.google.common.base.Absent</exclude>
+                    <exclude>com.google.common.base.Present</exclude>
+                  </excludes>
+                </relocation>
+              </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>


### PR DESCRIPTION
The following check inside datastax's Cluster type relies on guava 16+

```java
public class Cluster implements Closeable {

    private static final Logger logger = LoggerFactory.getLogger(Cluster.class);

    static {
        // Perform sanity checks to inform user of possible environment misconfiguration.
        SanityChecks.check();
    }
```

This change shades use of guava per https://issues.apache.org/jira/browse/SPARK-16725