### PR TITLE
Updates to zipkin 1.29.3 and fixes tests

### DIFF
--- a/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
+++ b/cassandra/src/test/java/zipkin/storage/cassandra/CassandraDependenciesTest.java
@@ -30,7 +30,7 @@ import static zipkin.internal.Util.midnightUTC;
 
 public class CassandraDependenciesTest extends DependenciesTest {
   @ClassRule public static LazyCassandraStorage storage =
-      new LazyCassandraStorage("openzipkin/zipkin-cassandra:1.29.2", "test_zipkin_dependency");
+      new LazyCassandraStorage("openzipkin/zipkin-cassandra:1.29.3", "test_zipkin_dependency");
 
   @Override protected CassandraStorage storage() {
     return storage.get();

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchV2DependenciesTest.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchV2DependenciesTest.java
@@ -18,7 +18,7 @@ import org.junit.ClassRule;
 public class ElasticsearchV2DependenciesTest extends ElasticsearchDependenciesTest {
 
   @ClassRule public static LazyElasticsearchHttpStorage storage =
-      new LazyElasticsearchHttpStorage("openzipkin/zipkin-elasticsearch:1.29.2");
+      new LazyElasticsearchHttpStorage("openzipkin/zipkin-elasticsearch:1.29.3");
 
   @Override protected ElasticsearchHttpStorage storage() {
     return storage.get();

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchV5DependenciesTest.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchV5DependenciesTest.java
@@ -18,7 +18,7 @@ import org.junit.ClassRule;
 public class ElasticsearchV5DependenciesTest extends ElasticsearchDependenciesTest {
 
   @ClassRule public static LazyElasticsearchHttpStorage storage =
-      new LazyElasticsearchHttpStorage("openzipkin/zipkin-elasticsearch5:1.29.2");
+      new LazyElasticsearchHttpStorage("openzipkin/zipkin-elasticsearch5:1.29.3");
 
   @Override protected ElasticsearchHttpStorage storage() {
     return storage.get();

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchV5WithSingleTypeIndexingDependenciesTest.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/ElasticsearchV5WithSingleTypeIndexingDependenciesTest.java
@@ -18,7 +18,7 @@ import org.junit.ClassRule;
 public class ElasticsearchV5WithSingleTypeIndexingDependenciesTest
     extends ElasticsearchDependenciesTest {
   @ClassRule public static LazyElasticsearchHttpStorage storage =
-      new LazyElasticsearchHttpStorage("openzipkin/zipkin-elasticsearch5:1.29.2", true);
+      new LazyElasticsearchHttpStorage("openzipkin/zipkin-elasticsearch5:1.29.3", true);
 
   @Override protected ElasticsearchHttpStorage storage() {
     return storage.get();

--- a/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/LazyElasticsearchHttpStorage.java
+++ b/elasticsearch/src/test/java/zipkin/storage/elasticsearch/http/LazyElasticsearchHttpStorage.java
@@ -29,7 +29,8 @@ import zipkin.internal.LazyCloseable;
 
 class LazyElasticsearchHttpStorage extends LazyCloseable<ElasticsearchHttpStorage>
     implements TestRule {
-  static final String INDEX = "test_zipkin_dependency";
+  /** Need to watch index pattern from 1970 doesn't result in a request line longer than 4096 */
+  static final String INDEX = "test_zipkin";
 
   final String image;
   final boolean singleTypeIndexingEnabled;

--- a/elasticsearch/src/test/resources/log4j.properties
+++ b/elasticsearch/src/test/resources/log4j.properties
@@ -33,6 +33,7 @@ log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
 log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
 
 log4j.logger.zipkin.dependencies.elasticsearch=DEBUG
+log4j.logger.zipkin.storage.elasticsearch.http=DEBUG
 # Set to DEBUG to see http traffic to elasticsearch from the spark job
 log4j.logger.httpclient.wire=INFO
 log4j.logger.org.testcontainers=INFO

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <!-- spark-cassandra-connector doesn't yet support spark 2.2 -->
     <spark.version>2.1.1</spark.version>
-    <zipkin.version>1.29.2</zipkin.version>
+    <zipkin.version>1.29.3</zipkin.version>
     <junit.version>4.12</junit.version>
     <assertj.version>3.8.0</assertj.version>
     <jackson.version>2.9.0</jackson.version>


### PR DESCRIPTION
Master was broken due to an unnecessarily long index name, which explodes in tests because it is applied to a pattern to search for spans since 1970