### PR TITLE
Fixes ZIPKIN_LOG_LEVEL after update to zipkin2

### DIFF
--- a/main/src/main/java/zipkin/dependencies/LogInitializer.java
+++ b/main/src/main/java/zipkin/dependencies/LogInitializer.java
@@ -56,6 +56,7 @@ import zipkin.internal.DependencyLinker;
 // after an task deserializes on an executor. Until such is available, this is the least touch way.
 public final class LogInitializer implements Serializable, Runnable {
   private static final long serialVersionUID = 0L;
+  static final String[] LOG_CATEGORIES = {"zipkin", "zipkin2"};
 
   /**
    * Call this prior to any phase to ensure zipkin logging is setup
@@ -75,14 +76,16 @@ public final class LogInitializer implements Serializable, Runnable {
   }
 
   @Override public void run() {
-    Logger zipkinLogger = LogManager.getLogger("zipkin");
-    if (!log4Jlevel.equals(zipkinLogger.getLevel())) {
-      zipkinLogger.setLevel(log4Jlevel);
-      if (zipkinLogger.getAdditivity()) {
-        addLogAppendersFromRoot(zipkinLogger);
+    for (String category : LOG_CATEGORIES) {
+      Logger zipkinLogger = LogManager.getLogger(category);
+      if (!log4Jlevel.equals(zipkinLogger.getLevel())) {
+        zipkinLogger.setLevel(log4Jlevel);
+        if (zipkinLogger.getAdditivity()) {
+          addLogAppendersFromRoot(zipkinLogger);
+        }
       }
+      java.util.logging.Logger.getLogger(category).setLevel(julLevel);
     }
-    java.util.logging.Logger.getLogger("zipkin").setLevel(julLevel);
   }
 
   private static java.util.logging.Level toJul(Level log4Jlevel) {


### PR DESCRIPTION
Example run that works again:

```bash
$ ZIPKIN_LOG_LEVEL=DEBUG STORAGE_TYPE=elasticsearch java -jar main/target/zipkin-dependencies-1.10.1-SNAPSHOT.jar
17/09/18 10:42:12 INFO ElasticsearchDependenciesJob: Processing spans from zipkin-2017-09-18/span
17/09/18 10:42:12 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
17/09/18 10:42:12 WARN Utils: Your hostname, acole resolves to a loopback address: 127.0.0.1; using 10.70.41.33 instead (on interface en0)
17/09/18 10:42:12 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
17/09/18 10:42:12 WARN Java7Support: Unable to load JDK7 types (annotations, java.nio.file.Path): no Java7 support added
17/09/18 10:42:13 INFO ElasticsearchDependenciesJob: No spans found at zipkin-2017-09-18/span
17/09/18 10:42:13 INFO ElasticsearchDependenciesJob: Processing spans from zipkin:span-2017-09-18/span
17/09/18 10:42:14 DEBUG DependencyLinker: traversing trace tree, breadth-first
17/09/18 10:42:14 DEBUG DependencyLinker: traversing trace tree, breadth-first
17/09/18 10:42:14 DEBUG DependencyLinker: processing {"traceId":"85675e7f59be3817","id":"85675e7f59be3817","kind":"SERVER","name":"get","timestamp":1505727135804063,"duration":2166871,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"remoteEndpoint":{"ipv4":"127.0.0.1","port":56340},"tags":{"http.path":"/a"}}
17/09/18 10:42:14 DEBUG DependencyLinker: processing {"traceId":"e5d8b57d4f8a4ba7","id":"e5d8b57d4f8a4ba7","kind":"SERVER","name":"get","timestamp":1505727139139793,"duration":1161994,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"remoteEndpoint":{"ipv4":"127.0.0.1","port":56350},"tags":{"http.path":"/a"}}
17/09/18 10:42:14 DEBUG DependencyLinker: root's peer is unknown; skipping
17/09/18 10:42:14 DEBUG DependencyLinker: root's peer is unknown; skipping
17/09/18 10:42:14 DEBUG DependencyLinker: processing {"traceId":"85675e7f59be3817","parentId":"85675e7f59be3817","id":"08758095999adc2f","kind":"SERVER","name":"get","timestamp":1505727136450361,"duration":705886,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"remoteEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"tags":{"http.path":"/b"},"shared":true}
17/09/18 10:42:14 DEBUG DependencyLinker: processing {"traceId":"e5d8b57d4f8a4ba7","parentId":"e5d8b57d4f8a4ba7","id":"5571cb79fb21520e","kind":"SERVER","name":"get","timestamp":1505727139538122,"duration":678677,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"remoteEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"tags":{"http.path":"/b"},"shared":true}
17/09/18 10:42:14 DEBUG DependencyLinker: processing ancestor {"traceId":"85675e7f59be3817","id":"85675e7f59be3817","kind":"SERVER","name":"get","timestamp":1505727135804063,"duration":2166871,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"remoteEndpoint":{"ipv4":"127.0.0.1","port":56340},"tags":{"http.path":"/a"}}
17/09/18 10:42:14 DEBUG DependencyLinker: processing ancestor {"traceId":"e5d8b57d4f8a4ba7","id":"e5d8b57d4f8a4ba7","kind":"SERVER","name":"get","timestamp":1505727139139793,"duration":1161994,"localEndpoint":{"serviceName":"brave-webmvc-example","ipv4":"10.70.41.33"},"remoteEndpoint":{"ipv4":"127.0.0.1","port":56350},"tags":{"http.path":"/a"}}
17/09/18 10:42:14 DEBUG DependencyLinker: incrementing link brave-webmvc-example -> brave-webmvc-example
17/09/18 10:42:14 DEBUG DependencyLinker: incrementing link brave-webmvc-example -> brave-webmvc-example
17/09/18 10:42:14 INFO ElasticsearchDependenciesJob: Saving dependency links to zipkin:dependency-2017-09-18/dependency
17/09/18 10:42:14 INFO ElasticsearchDependenciesJob: Done
```