### PR TITLE
Ensures the job can be run standalone even if unzipped

### DIFF
--- a/main/src/main/java/zipkin/dependencies/ZipkinDependenciesJob.java
+++ b/main/src/main/java/zipkin/dependencies/ZipkinDependenciesJob.java
@@ -13,6 +13,7 @@
  */
 package zipkin.dependencies;
 
+import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -26,7 +27,7 @@ import zipkin.dependencies.mysql.MySQLDependenciesJob;
 public final class ZipkinDependenciesJob {
   /** Runs with defaults, starting today */
   public static void main(String[] args) throws UnsupportedEncodingException {
-    String jarPath = pathToUberJar();
+    String[] jarPath = pathToUberJar();
     long day = args.length == 1 ? parseDay(args[0]) : System.currentTimeMillis();
     String storageType = System.getenv("STORAGE_TYPE");
     if (storageType == null) {
@@ -76,9 +77,10 @@ public final class ZipkinDependenciesJob {
     }
   }
 
-  static String pathToUberJar() throws UnsupportedEncodingException {
+  static String[] pathToUberJar() throws UnsupportedEncodingException {
     URL jarFile = ZipkinDependenciesJob.class.getProtectionDomain().getCodeSource().getLocation();
-    return URLDecoder.decode(jarFile.getPath(), "UTF-8");
+    return new File(jarFile.getPath()).isDirectory() ? null
+        : new String[] {URLDecoder.decode(jarFile.getPath(), "UTF-8")};
   }
 
   static long parseDay(String formattedDate) {


### PR DESCRIPTION
Prevents this in cloud foundry, which unzips jars:
```
2018-06-12T15:56:13.65+0200 [APP/PROC/WEB/0] OUT JVM Memory Configuration: -Xmx1406944K -Xss1M -XX:ReservedCodeCacheSize=240M -XX:MaxDirectMemorySize=10M -XX:MaxMetaspaceSize=178207K
2018-06-12T15:56:14.02+0200 [APP/PROC/WEB/0] ERR 18/06/12 13:56:14 INFO ElasticsearchDependenciesJob: Processing spans from zipkin-2018-06-12/span
2018-06-12T15:56:14.25+0200 [APP/PROC/WEB/0] ERR 18/06/12 13:56:14 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 18/06/12 13:56:14 ERROR SparkContext: Failed to add /home/vcap/app/ to Spark environment
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR java.lang.IllegalArgumentException: Directory /home/vcap/app is not allowed for addJar
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at org.apache.spark.SparkContext.addJarFile$1(SparkContext.scala:1817)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at org.apache.spark.SparkContext.addJar(SparkContext.scala:1840)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at org.apache.spark.SparkContext$$anonfun$12.apply(SparkContext.scala:466)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at org.apache.spark.SparkContext$$anonfun$12.apply(SparkContext.scala:466)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at scala.collection.immutable.List.foreach(List.scala:381)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at org.apache.spark.SparkContext.<init>(SparkContext.scala:466)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at zipkin.dependencies.elasticsearch.ElasticsearchDependenciesJob.run(ElasticsearchDependenciesJob.java:179)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at zipkin.dependencies.elasticsearch.ElasticsearchDependenciesJob.run(ElasticsearchDependenciesJob.java:165)
2018-06-12T15:56:14.84+0200 [APP/PROC/WEB/0] ERR 	at zipkin.dependencies.ZipkinDependenciesJob.main(ZipkinDependenciesJob.java:72)
```

Fixes #106