### PR TITLE
use ${scala.binary.version} for jackson-scala dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-scala_2.11</artifactId>
+        <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
this increases consistency and makes it possible to build against
different Scala versions.