### PR TITLE
Bumps version of jackson-databind lib to tackle CVE-2019-14379

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <junit.version>4.12</junit.version>
     <assertj.version>3.13.2</assertj.version>
     <jackson.version>2.9.9</jackson.version>
+    <jackson-databind.version>2.9.9.3</jackson-databind.version>
     <!-- connector uses an old version of the driver -->
     <cassandra-driver-core.version>3.7.2</cassandra-driver-core.version>
     <spark-cassandra-connector.version>2.4.1</spark-cassandra-connector.version>
@@ -179,10 +180,11 @@
         <artifactId>jackson-core</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+      <!-- Forcibly bump Jackson Databind version to avoid CVE-2019-14379 -->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-databind.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The version of jackson-databind in use, 2.9.9, is said to be vulnerable. The version 2.9.9.2 has fixed this issue. I've picked 2.9.9.3, the latest patch in the minor version.

As I'm new to the project, is there a quick way we can assure this doesn't break core? Otherwise, please let me know how else I can manually integration-test this patch.

Cheers,
Greg