### PR TITLE
Revert 0.0.0

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.0</version>
+    <version>2.3.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-dependencies-cassandra</artifactId>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.0</version>
   </parent>
 
   <artifactId>zipkin-dependencies-cassandra</artifactId>

--- a/cassandra3/pom.xml
+++ b/cassandra3/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.0</version>
   </parent>
 
   <artifactId>zipkin-dependencies-cassandra3</artifactId>

--- a/cassandra3/pom.xml
+++ b/cassandra3/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.0</version>
+    <version>2.3.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-dependencies-cassandra3</artifactId>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.0</version>
+    <version>2.3.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-dependencies-elasticsearch</artifactId>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.0</version>
   </parent>
 
   <artifactId>zipkin-dependencies-elasticsearch</artifactId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.0</version>
+    <version>2.3.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-dependencies</artifactId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.0</version>
   </parent>
 
   <artifactId>zipkin-dependencies</artifactId>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.0</version>
+    <version>2.3.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-dependencies-mysql</artifactId>

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.dependencies</groupId>
     <artifactId>zipkin-dependencies-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.0</version>
   </parent>
 
   <artifactId>zipkin-dependencies-mysql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.dependencies</groupId>
   <artifactId>zipkin-dependencies-parent</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -89,7 +89,7 @@
     <url>https://github.com/openzipkin/zipkin-dependencies</url>
     <connection>scm:git:https://github.com/openzipkin/zipkin-dependencies.git</connection>
     <developerConnection>scm:git:https://github.com/openzipkin/zipkin-dependencies.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>0.0.0</tag>
   </scm>
 
   <!-- Developer section is needed for Maven Central, but doesn't need to include each person -->

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.dependencies</groupId>
   <artifactId>zipkin-dependencies-parent</artifactId>
-  <version>0.0.0</version>
+  <version>2.3.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -89,7 +89,7 @@
     <url>https://github.com/openzipkin/zipkin-dependencies</url>
     <connection>scm:git:https://github.com/openzipkin/zipkin-dependencies.git</connection>
     <developerConnection>scm:git:https://github.com/openzipkin/zipkin-dependencies.git</developerConnection>
-    <tag>0.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Developer section is needed for Maven Central, but doesn't need to include each person -->


### PR DESCRIPTION
This reverts changes made by the maven release plugin when testing out the 0.0.0 test tag - in the future, I should disable travis temporarily when trying a docker release.