### PR TITLE
Update zipkin-dependencies-yesterday

### DIFF
--- a/docker/periodic/daily/zipkin-dependencies-yesterday
+++ b/docker/periodic/daily/zipkin-dependencies-yesterday
@@ -1,2 +1,2 @@
 #!/bin/sh
-java ${JAVA_OPTS} -jar /zipkin-dependencies/zipkin-dependencies.jar `date -ud yesterday +%F`
+java ${JAVA_OPTS} -jar /zipkin-dependencies/zipkin-dependencies*.jar `date -ud yesterday +%F`


### PR DESCRIPTION
because the latest jar lib name is zipkin-dependencies-2.4.1.jar, so this crond cannot effect