### PR TITLE
Reverts pom changes that seemed redundant

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -31,6 +31,12 @@
   </properties>
 
   <dependencies>
+    <!-- Force the newer Netty 4.1 in spark to vs Cassandra's version -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.datastax.spark</groupId>
       <artifactId>spark-cassandra-connector-unshaded_${scala.binary.version}</artifactId>

--- a/cassandra3/pom.xml
+++ b/cassandra3/pom.xml
@@ -31,6 +31,12 @@
   </properties>
 
   <dependencies>
+    <!-- Force the newer Netty 4.1 in spark to vs Cassandra's version -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.datastax.spark</groupId>
       <artifactId>spark-cassandra-connector-unshaded_${scala.binary.version}</artifactId>


### PR DESCRIPTION
There were entries in the pom for cassandra that were not commented why.
These were here to force netty version, so I added the why. You can
verify using the below (or noticing tests now pass!)

```bash
$ ./mvnw dependency:tree -Dverbose -Dincludes=io.netty:netty-all
```

See also https://datastax-oss.atlassian.net/browse/SPARKC-557 which I suspect will be obviated once the spark driver switches to the datastax 4.x client