### PR TITLE
Updates to latest Zipkin and Cassandra driver

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -31,15 +31,9 @@
   </properties>
 
   <dependencies>
-    <!-- Force the newer Netty 4.1 in spark to vs Cassandra's version -->
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.datastax.spark</groupId>
-      <artifactId>spark-cassandra-connector-unshaded_${scala.binary.version}</artifactId>
+      <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
       <version>${spark-cassandra-connector.version}</version>
     </dependency>
 

--- a/cassandra/src/main/java/zipkin2/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/cassandra/src/main/java/zipkin2/dependencies/cassandra/CassandraDependenciesJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +13,15 @@
  */
 package zipkin2.dependencies.cassandra;
 
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.spark.connector.cql.CassandraConnector;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -51,10 +52,9 @@ public final class CassandraDependenciesJob {
   }
 
   public static final class Builder {
-
     String keyspace = getEnv("CASSANDRA_KEYSPACE", "zipkin");
     String contactPoints = getEnv("CASSANDRA_CONTACT_POINTS", "localhost");
-    String localDc = getEnv("CASSANDRA_LOCAL_DC", null);
+    String localDc = getEnv("CASSANDRA_LOCAL_DC", "datacenter1");
     // local[*] master lets us run & test the job locally without setting a Spark cluster
     String sparkMaster = getEnv("SPARK_MASTER", "local[*]");
     // needed when not in local mode
@@ -68,16 +68,21 @@ public final class CassandraDependenciesJob {
 
     Builder() {
       sparkProperties.put("spark.ui.enabled", "false");
+
       sparkProperties.put(
-          "spark.cassandra.connection.ssl.enabled", getEnv("CASSANDRA_USE_SSL", "false"));
+        "spark.cassandra.connection.ssl.enabled", getEnv("CASSANDRA_USE_SSL", "false"));
       sparkProperties.put(
-          "spark.cassandra.connection.ssl.trustStore.password",
-          System.getProperty("javax.net.ssl.trustStorePassword", ""));
+        "spark.cassandra.connection.ssl.trustStore.password",
+        System.getProperty("javax.net.ssl.trustStorePassword", ""));
       sparkProperties.put(
-          "spark.cassandra.connection.ssl.trustStore.path",
-          System.getProperty("javax.net.ssl.trustStore", ""));
-      sparkProperties.put("spark.cassandra.auth.username", getEnv("CASSANDRA_USERNAME", ""));
-      sparkProperties.put("spark.cassandra.auth.password", getEnv("CASSANDRA_PASSWORD", ""));
+        "spark.cassandra.connection.ssl.trustStore.path",
+        System.getProperty("javax.net.ssl.trustStore", ""));
+
+      String username = getEnv("CASSANDRA_USERNAME", null);
+      if (username != null && !"".equals(username)) {
+        sparkProperties.put("spark.cassandra.auth.username", username);
+        sparkProperties.put("spark.cassandra.auth.password", getEnv("CASSANDRA_PASSWORD", ""));
+      }
     }
 
     /** When set, this indicates which jars to distribute to the cluster. */
@@ -127,7 +132,7 @@ public final class CassandraDependenciesJob {
     }
   }
 
-  private static String getEnv(String key, String defaultValue) {
+  @Nullable static String getEnv(String key, String defaultValue) {
     String result = System.getenv(key);
     return result != null ? result : defaultValue;
   }
@@ -147,7 +152,7 @@ public final class CassandraDependenciesJob {
     this.conf = new SparkConf(true).setMaster(builder.sparkMaster).setAppName(getClass().getName());
     conf.set("spark.cassandra.connection.host", parseHosts(builder.contactPoints));
     conf.set("spark.cassandra.connection.port", parsePort(builder.contactPoints));
-    if (builder.localDc != null) conf.set("connection.local_dc", builder.localDc);
+    conf.set("spark.cassandra.connection.localDC", builder.localDc);
     if (builder.jars != null) conf.setJars(builder.jars);
     for (Map.Entry<String, String> entry : builder.sparkProperties.entrySet()) {
       conf.set(entry.getKey(), entry.getValue());
@@ -161,13 +166,14 @@ public final class CassandraDependenciesJob {
     long microsUpper = (day * 1000) + TimeUnit.DAYS.toMicros(1) - 1;
 
     log.info("Running Dependencies job for {}: {} ≤ Span.timestamp {}", dateStamp, microsLower,
-        microsUpper);
+      microsUpper);
 
     SparkContext sc = new SparkContext(conf);
 
     List<DependencyLink> links = javaFunctions(sc)
       .cassandraTable(keyspace, "traces")
-      .spanBy(r -> r.getLong("trace_id"), Long.class)
+      .select("trace_id", "span")
+      .spanBy(r -> r.getLong(0), Long.class)
       .flatMapValues(new CassandraRowsToDependencyLinks(logInitializer, microsLower, microsUpper))
       .values()
       .mapToPair(l -> Tuple2.apply(Tuple2.apply(l.parent(), l.child()), l))
@@ -186,16 +192,17 @@ public final class CassandraDependenciesJob {
   }
 
   void saveToCassandra(List<DependencyLink> links) {
-    Dependencies thrift = Dependencies.create(day, day /** ignored */, links);
+    Dependencies thrift = Dependencies.create(day, day /* ignored */, links);
     ByteBuffer blob = thrift.toThrift();
 
     log.info("Saving with day={}", dateStamp);
-    CassandraConnector.apply(conf).withSessionDo(new AbstractFunction1<Session, Void>() {
-      @Override public Void apply(Session session) {
-        session.execute(QueryBuilder.insertInto(keyspace, "dependencies")
-            .value("day", new Date(day))
-            .value("dependencies", blob)
-        );
+    CassandraConnector.apply(conf).withSessionDo(new AbstractFunction1<CqlSession, Void>() {
+      @Override public Void apply(CqlSession session) {
+        PreparedStatement prepared =
+          session.prepare(
+            "INSERT INTO " + keyspace + ".dependencies (day,dependencies) VALUES (?,?)");
+
+        session.execute(prepared.bind(Instant.ofEpochMilli(day), blob));
         return null;
       }
     });

--- a/cassandra/src/test/java/zipkin2/dependencies/cassandra/CassandraDependenciesJobTest.java
+++ b/cassandra/src/test/java/zipkin2/dependencies/cassandra/CassandraDependenciesJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,39 +20,34 @@ import static zipkin2.dependencies.cassandra.CassandraDependenciesJob.parseHosts
 import static zipkin2.dependencies.cassandra.CassandraDependenciesJob.parsePort;
 
 public class CassandraDependenciesJobTest {
-  @Test
-  public void parseHosts_ignoresPortSection() {
+  @Test public void parseHosts_ignoresPortSection() {
     assertThat(parseHosts("1.1.1.1:9142"))
-        .isEqualTo("1.1.1.1");
+      .isEqualTo("1.1.1.1");
   }
 
-  @Test
-  public void parseHosts_commaDelimits() {
+  @Test public void parseHosts_commaDelimits() {
     assertThat(parseHosts("1.1.1.1:9143,2.2.2.2:9143"))
-        .isEqualTo("1.1.1.1,2.2.2.2");
+      .isEqualTo("1.1.1.1,2.2.2.2");
   }
 
-  @Test
-  public void parsePort_ignoresHostSection() {
+  @Test public void parsePort_ignoresHostSection() {
     assertThat(parsePort("1.1.1.1:9142"))
-        .isEqualTo("9142");
+      .isEqualTo("9142");
   }
 
   @Test
   public void parsePort_multiple_consistent() {
     assertThat(parsePort("1.1.1.1:9143,2.2.2.2:9143"))
-        .isEqualTo("9143");
+      .isEqualTo("9143");
   }
 
-  @Test
-  public void parsePort_defaultsTo9042() {
+  @Test public void parsePort_defaultsTo9042() {
     assertThat(parsePort("1.1.1.1"))
-        .isEqualTo("9042");
+      .isEqualTo("9042");
   }
 
-  @Test
-  public void parsePort_defaultsTo9042_multi() {
+  @Test public void parsePort_defaultsTo9042_multi() {
     assertThat(parsePort("1.1.1.1:9143,2.2.2.2"))
-        .isEqualTo("9042");
+      .isEqualTo("9042");
   }
 }

--- a/cassandra/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
+++ b/cassandra/src/test/java/zipkin2/storage/cassandra/v1/CassandraStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,11 +13,16 @@
  */
 package zipkin2.storage.cassandra.v1;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.HostDistance;
-import com.datastax.driver.core.PoolingOptions;
-import com.datastax.driver.core.Session;
-import java.net.InetSocketAddress;
+import com.codahale.metrics.Gauge;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -28,17 +33,40 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static zipkin2.Call.propagateIfFatal;
+import static zipkin2.storage.cassandra.v1.Tables.DEPENDENCIES;
+import static zipkin2.storage.cassandra.v1.Tables.TRACES;
+
 public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCallback {
+  static final List<String> SEARCH_TABLES = asList(
+    Tables.AUTOCOMPLETE_TAGS,
+    Tables.REMOTE_SERVICE_NAMES,
+    Tables.SPAN_NAMES,
+    Tables.SERVICE_NAMES,
+    Tables.ANNOTATIONS_INDEX,
+    Tables.SERVICE_REMOTE_SERVICE_NAME_INDEX,
+    Tables.SERVICE_SPAN_NAME_INDEX,
+    Tables.SERVICE_SPAN_NAME_INDEX
+  );
   static final Logger LOGGER = LoggerFactory.getLogger(CassandraStorageExtension.class);
   static final int CASSANDRA_PORT = 9042;
   final String image;
   CassandraContainer container;
+  CqlSession globalSession;
 
   CassandraStorageExtension(String image) {
     this.image = image;
   }
 
   @Override public void beforeAll(ExtensionContext context) {
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
+    }
+
     if (!"true".equals(System.getProperty("docker.skip"))) {
       try {
         LOGGER.info("Starting docker image " + image);
@@ -50,30 +78,68 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
     } else {
       LOGGER.info("Skipping startup of docker " + image);
     }
+    assumeTrue(container != null, "Docker not available");
+
+    globalSession = tryToInitializeSession(contactPoint());
+    LOGGER.info("Using contactPoint " + contactPoint());
   }
 
-  CassandraStorage.Builder computeStorageBuilder() {
-    InetSocketAddress contactPoint = contactPoint();
-    return CassandraStorage.newBuilder()
-      .contactPoints(contactPoint.getHostString() + ":" + contactPoint.getPort())
-      .ensureSchema(true)
-      .keyspace("test_cassandra");
-  }
-
-  InetSocketAddress contactPoint() {
-    if (container != null && container.isRunning()) {
-      return new InetSocketAddress(
-        container.getContainerIpAddress(), container.getMappedPort(CASSANDRA_PORT));
-    } else {
-      return new InetSocketAddress("127.0.0.1", CASSANDRA_PORT);
+  // Builds a session without trying to use a namespace or init UDTs
+  static CqlSession tryToInitializeSession(String contactPoint) {
+    CassandraStorage storage = newStorageBuilder(contactPoint).build();
+    CqlSession session = null;
+    try {
+      session = SessionFactory.Default.buildSession(storage);
+      session.execute("SELECT now() FROM system.local");
+    } catch (Throwable e) {
+      propagateIfFatal(e);
+      if (session != null) session.close();
+      assumeTrue(false, e.getMessage());
     }
+    return session;
+  }
+
+  CassandraStorage.Builder newStorageBuilder() {
+    return newStorageBuilder(contactPoint());
+  }
+
+  static CassandraStorage.Builder newStorageBuilder(String contactPoint) {
+    return CassandraStorage.newBuilder().contactPoints(contactPoint).maxConnections(1);
+  }
+
+  String contactPoint() {
+    return container.getContainerIpAddress() + ":" + container.getMappedPort(CASSANDRA_PORT);
+  }
+
+  void clear(CassandraStorage storage) {
+    // Clear any key cache
+    CassandraSpanConsumer spanConsumer = storage.spanConsumer;
+    if (spanConsumer != null) spanConsumer.clear();
+
+    CqlSession session = storage.session.session;
+    if (session == null) session = globalSession;
+
+    List<String> toTruncate = new ArrayList<>(SEARCH_TABLES);
+    toTruncate.add(DEPENDENCIES);
+    toTruncate.add(TRACES);
+
+    for (String table : toTruncate) {
+      try {
+        session.execute("TRUNCATE " + storage.keyspace + "." + table);
+      } catch (InvalidQueryException e) {
+        assertThat(e).hasMessage("unconfigured table " + table);
+      }
+    }
+
+    blockWhileInFlight(storage);
   }
 
   @Override public void afterAll(ExtensionContext context) {
-    if (container != null) {
-      LOGGER.info("Stopping docker image " + image);
-      container.stop();
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
     }
+    if (globalSession != null) globalSession.close();
   }
 
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
@@ -82,29 +148,53 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
     }
 
     @Override protected void waitUntilContainerStarted() {
-      Unreliables.retryUntilSuccess(2, TimeUnit.MINUTES, () -> {
-        if (!isRunning()) {
-          throw new ContainerLaunchException("Container failed to start");
-        }
+      Unreliables.retryUntilSuccess(120, TimeUnit.SECONDS, () -> {
+        if (!isRunning()) throw new ContainerLaunchException("Container failed to start");
 
-        InetSocketAddress address =
-          new InetSocketAddress(getContainerIpAddress(), getMappedPort(9042));
-
-        try (Cluster cluster = getCluster(address); Session session = cluster.newSession()) {
+        String contactPoint = getContainerIpAddress() + ":" + getMappedPort(9042);
+        try (CqlSession session = tryToInitializeSession(contactPoint)) {
           session.execute("SELECT now() FROM system.local");
-          logger().info("Obtained a connection to container ({})", cluster.getClusterName());
+          logger().info("Obtained a connection to container ({})", contactPoint);
           return null; // unused value
         }
       });
     }
   }
 
-  static Cluster getCluster(InetSocketAddress contactPoint) {
-    return Cluster.builder()
-      .withoutJMXReporting()
-      .addContactPointsWithPorts(contactPoint)
-      .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
-      .withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(HostDistance.LOCAL, 1))
-      .build();
+  static void blockWhileInFlight(CassandraStorage storage) {
+    CqlSession session = storage.session.get();
+    // Now, block until writes complete, notably so we can read them.
+    boolean wasInFlight = false;
+    while (true) {
+      if (!poolInFlight(session)) {
+        if (wasInFlight) sleep(100); // give a little more to avoid flakey tests
+        return;
+      }
+      wasInFlight = true;
+      sleep(100);
+    }
+  }
+
+  static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+
+  // Use metrics to wait for in-flight requests to settle per
+  // https://groups.google.com/a/lists.datastax.com/g/java-driver-user/c/5um_yGNynow/m/cInH5I5jBgAJ
+  static boolean poolInFlight(CqlSession session) {
+    Collection<Node> nodes = session.getMetadata().getNodes().values();
+    Optional<Metrics> metrics = session.getMetrics();
+    for (Node node : nodes) {
+      int inFlight = metrics.flatMap(m -> m.getNodeMetric(node, DefaultNodeMetric.IN_FLIGHT))
+        .map(m -> ((Gauge<Integer>) m).getValue())
+        .orElse(0);
+      if (inFlight > 0) return true;
+    }
+    return false;
   }
 }

--- a/cassandra/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraDependencies.java
+++ b/cassandra/src/test/java/zipkin2/storage/cassandra/v1/ITCassandraDependencies.java
@@ -13,51 +13,64 @@
  */
 package zipkin2.storage.cassandra.v1;
 
-import com.datastax.driver.core.Host;
-import com.datastax.driver.core.Session;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import zipkin2.Span;
 import zipkin2.dependencies.cassandra.CassandraDependenciesJob;
-import zipkin2.storage.ITDependencies;
-import zipkin2.storage.StorageComponent;
+
+import static zipkin2.storage.ITDependencies.aggregateLinks;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ITCassandraDependencies extends ITDependencies<CassandraStorage> {
+class ITCassandraDependencies {
   @RegisterExtension CassandraStorageExtension backend = new CassandraStorageExtension(
-    "openzipkin/zipkin-cassandra:2.21.7");
+    "openzipkin/zipkin-cassandra:2.22.0");
 
-  String keyspace;
+  @Nested
+  class ITDependencies extends zipkin2.storage.ITDependencies<CassandraStorage> {
 
-  @Override protected boolean initializeStoragePerTest() {
-    return true;
+    @Override protected CassandraStorage.Builder newStorageBuilder(TestInfo testInfo) {
+      return backend.newStorageBuilder();
+    }
+
+    @Override public void clear() {
+      backend.clear(storage);
+    }
+
+    @Override protected void processDependencies(List<Span> spans) throws Exception {
+      ITCassandraDependencies.this.processDependencies(storage, spans);
+    }
   }
 
-  @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
-    keyspace = testInfo.getTestMethod().get().getName().toLowerCase();
-    if (keyspace.length() > 48) keyspace = keyspace.substring(keyspace.length() - 48);
-    return backend.computeStorageBuilder().keyspace(keyspace);
-  }
+  @Nested
+  class ITDependenciesHeavy extends zipkin2.storage.ITDependenciesHeavy<CassandraStorage> {
 
-  @Override public void clear() {
-    // Just let the data pile up to prevent warnings and slowness.
+    @Override protected CassandraStorage.Builder newStorageBuilder(TestInfo testInfo) {
+      return backend.newStorageBuilder();
+    }
+
+    @Override public void clear() {
+      backend.clear(storage);
+    }
+
+    @Override protected void processDependencies(List<Span> spans) throws Exception {
+      ITCassandraDependencies.this.processDependencies(storage, spans);
+    }
   }
 
   /**
    * This processes the job as if it were a batch. For each day we had traces, run the job again.
    */
-  @Override protected void processDependencies(List<Span> spans) throws Exception {
+  void processDependencies(CassandraStorage storage, List<Span> spans) throws Exception {
     // TODO: this avoids overrunning the cluster with BusyPoolException
     for (List<Span> nextChunk : Lists.partition(spans, 100)) {
       storage.spanConsumer().accept(nextChunk).execute();
       // Now, block until writes complete, notably so we can read them.
-      blockWhileInFlight(storage);
+      CassandraStorageExtension.blockWhileInFlight(storage);
     }
 
     // aggregate links in memory to determine which days they are in
@@ -66,28 +79,12 @@ class ITCassandraDependencies extends ITDependencies<CassandraStorage> {
     // process the job for each day of links.
     for (long day : days) {
       CassandraDependenciesJob.builder()
-        .keyspace(keyspace)
+        .keyspace(storage.keyspace)
         .localDc(storage.localDc)
         .contactPoints(storage.contactPoints)
         .day(day)
         .build()
         .run();
-    }
-  }
-
-  static void blockWhileInFlight(CassandraStorage storage) {
-    // Now, block until writes complete, notably so we can read them.
-    Session.State state = storage.session().getState();
-    refresh:
-    while (true) {
-      for (Host host : state.getConnectedHosts()) {
-        if (state.getInFlightQueries(host) > 0) {
-          Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-          state = storage.session().getState();
-          continue refresh;
-        }
-      }
-      break;
     }
   }
 }

--- a/cassandra/src/test/resources/log4j.properties
+++ b/cassandra/src/test/resources/log4j.properties
@@ -16,7 +16,17 @@ log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
 log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
 
 log4j.logger.zipkin2=WARN
-log4j.logger.org.testcontainers=INFO
-log4j.logger.org.apache.http=WARN
-log4j.logger.com.github.dockerjava=WARN
-log4j.logger.org.zeroturnaround.exec=WARN
+
+# our tests check for schema portability, so hush lack of schema logs
+log4j.logger.zipkin2.storage.cassandra.v1.Schema=off
+# don't spam about SASI
+log4j.logger.com.datastax.oss.driver.internal.core.cql.CqlRequestHandler=error
+# ignore connection close errors when polling for cassandra to start
+log4j.logger.com.datastax.oss.driver.internal.core.control.ControlConnection=error
+# ignore warnings about too many sessions
+log4j.logger.com.datastax.oss.driver.internal.core.session.DefaultSession=error
+# stop huge spam
+log4j.logger.org.testcontainers.dockerclient=off
+
+# Schema install takes a while. Log basic information to prevent CI from thinking things are hung
+log4j.logger.zipkin2.storage.cassandra.v1.CassandraStorageExtension=info

--- a/cassandra3/pom.xml
+++ b/cassandra3/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -31,15 +33,9 @@
   </properties>
 
   <dependencies>
-    <!-- Force the newer Netty 4.1 in spark to vs Cassandra's version -->
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.datastax.spark</groupId>
-      <artifactId>spark-cassandra-connector-unshaded_${scala.binary.version}</artifactId>
+      <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
       <version>${spark-cassandra-connector.version}</version>
     </dependency>
 

--- a/cassandra3/src/main/java/zipkin2/dependencies/cassandra3/SpansToDependencyLinks.java
+++ b/cassandra3/src/main/java/zipkin2/dependencies/cassandra3/SpansToDependencyLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,7 +24,7 @@ import zipkin2.Span;
 import zipkin2.internal.DependencyLinker;
 
 final class SpansToDependencyLinks
-    implements Serializable, Function<Iterable<Span>, Iterable<DependencyLink>> {
+  implements Serializable, Function<Iterable<Span>, Iterable<DependencyLink>> {
   private static final long serialVersionUID = 0L;
 
   @Nullable final Runnable logInitializer;
@@ -37,8 +37,7 @@ final class SpansToDependencyLinks
     this.endTs = endTs;
   }
 
-  @Override
-  public Iterable<DependencyLink> call(Iterable<Span> spans) {
+  @Override public Iterable<DependencyLink> call(Iterable<Span> spans) {
     if (logInitializer != null) logInitializer.run();
     List<Span> sameTraceId = new ArrayList<>();
     for (Span span : spans) {

--- a/cassandra3/src/test/java/zipkin2/dependencies/cassandra3/CassandraDependenciesJobTest.java
+++ b/cassandra3/src/test/java/zipkin2/dependencies/cassandra3/CassandraDependenciesJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,39 +20,33 @@ import static zipkin2.dependencies.cassandra3.CassandraDependenciesJob.parseHost
 import static zipkin2.dependencies.cassandra3.CassandraDependenciesJob.parsePort;
 
 public class CassandraDependenciesJobTest {
-  @Test
-  public void parseHosts_ignoresPortSection() {
+  @Test public void parseHosts_ignoresPortSection() {
     assertThat(parseHosts("1.1.1.1:9142"))
-        .isEqualTo("1.1.1.1");
+      .isEqualTo("1.1.1.1");
   }
 
-  @Test
-  public void parseHosts_commaDelimits() {
+  @Test public void parseHosts_commaDelimits() {
     assertThat(parseHosts("1.1.1.1:9143,2.2.2.2:9143"))
-        .isEqualTo("1.1.1.1,2.2.2.2");
+      .isEqualTo("1.1.1.1,2.2.2.2");
   }
 
-  @Test
-  public void parsePort_ignoresHostSection() {
+  @Test public void parsePort_ignoresHostSection() {
     assertThat(parsePort("1.1.1.1:9142"))
-        .isEqualTo("9142");
+      .isEqualTo("9142");
   }
 
-  @Test
-  public void parsePort_multiple_consistent() {
+  @Test public void parsePort_multiple_consistent() {
     assertThat(parsePort("1.1.1.1:9143,2.2.2.2:9143"))
-        .isEqualTo("9143");
+      .isEqualTo("9143");
   }
 
-  @Test
-  public void parsePort_defaultsTo9042() {
+  @Test public void parsePort_defaultsTo9042() {
     assertThat(parsePort("1.1.1.1"))
-        .isEqualTo("9042");
+      .isEqualTo("9042");
   }
 
-  @Test
-  public void parsePort_defaultsTo9042_multi() {
+  @Test public void parsePort_defaultsTo9042_multi() {
     assertThat(parsePort("1.1.1.1:9143,2.2.2.2"))
-        .isEqualTo("9042");
+      .isEqualTo("9042");
   }
 }

--- a/cassandra3/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
+++ b/cassandra3/src/test/java/zipkin2/storage/cassandra/CassandraStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,11 +13,16 @@
  */
 package zipkin2.storage.cassandra;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.HostDistance;
-import com.datastax.driver.core.PoolingOptions;
-import com.datastax.driver.core.Session;
-import java.net.InetSocketAddress;
+import com.codahale.metrics.Gauge;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -27,18 +32,44 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
+import zipkin2.storage.cassandra.CassandraStorage.SessionFactory;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static zipkin2.Call.propagateIfFatal;
+import static zipkin2.storage.cassandra.Schema.TABLE_AUTOCOMPLETE_TAGS;
+import static zipkin2.storage.cassandra.Schema.TABLE_DEPENDENCY;
+import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_REMOTE_SERVICES;
+import static zipkin2.storage.cassandra.Schema.TABLE_SERVICE_SPANS;
+import static zipkin2.storage.cassandra.Schema.TABLE_SPAN;
+import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE;
+import static zipkin2.storage.cassandra.Schema.TABLE_TRACE_BY_SERVICE_SPAN;
 
 public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCallback {
+  static final List<String> SEARCH_TABLES = asList(
+    TABLE_AUTOCOMPLETE_TAGS,
+    TABLE_SERVICE_REMOTE_SERVICES,
+    TABLE_SERVICE_SPANS,
+    TABLE_TRACE_BY_SERVICE_REMOTE_SERVICE,
+    TABLE_TRACE_BY_SERVICE_SPAN
+  );
   static final Logger LOGGER = LoggerFactory.getLogger(CassandraStorageExtension.class);
   static final int CASSANDRA_PORT = 9042;
   final String image;
   CassandraContainer container;
+  CqlSession globalSession;
 
   CassandraStorageExtension(String image) {
     this.image = image;
   }
 
   @Override public void beforeAll(ExtensionContext context) {
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
+    }
+
     if (!"true".equals(System.getProperty("docker.skip"))) {
       try {
         LOGGER.info("Starting docker image " + image);
@@ -50,30 +81,69 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
     } else {
       LOGGER.info("Skipping startup of docker " + image);
     }
+
+    assumeTrue(container != null, "Docker not available");
+
+    globalSession = tryToInitializeSession(contactPoint());
+    LOGGER.info("Using contactPoint " + contactPoint());
   }
 
-  CassandraStorage.Builder computeStorageBuilder() {
-    InetSocketAddress contactPoint = contactPoint();
-    return CassandraStorage.newBuilder()
-      .contactPoints(contactPoint.getHostString() + ":" + contactPoint.getPort())
-      .ensureSchema(true)
-      .keyspace("test_cassandra3");
-  }
-
-  InetSocketAddress contactPoint() {
-    if (container != null && container.isRunning()) {
-      return new InetSocketAddress(
-        container.getContainerIpAddress(), container.getMappedPort(CASSANDRA_PORT));
-    } else {
-      return new InetSocketAddress("127.0.0.1", CASSANDRA_PORT);
+  // Builds a session without trying to use a namespace or init UDTs
+  static CqlSession tryToInitializeSession(String contactPoint) {
+    CassandraStorage storage = newStorageBuilder(contactPoint).build();
+    CqlSession session = null;
+    try {
+      session = SessionFactory.DEFAULT.create(storage);
+      session.execute("SELECT now() FROM system.local");
+    } catch (Throwable e) {
+      propagateIfFatal(e);
+      if (session != null) session.close();
+      assumeTrue(false, e.getMessage());
     }
+    return session;
+  }
+
+  CassandraStorage.Builder newStorageBuilder() {
+    return newStorageBuilder(contactPoint());
+  }
+
+  static CassandraStorage.Builder newStorageBuilder(String contactPoint) {
+    return CassandraStorage.newBuilder().contactPoints(contactPoint).maxConnections(1);
+  }
+
+  String contactPoint() {
+    return container.getContainerIpAddress() + ":" + container.getMappedPort(CASSANDRA_PORT);
+  }
+
+  void clear(CassandraStorage storage) {
+    // Clear any key cache
+    CassandraSpanConsumer spanConsumer = storage.spanConsumer;
+    if (spanConsumer != null) spanConsumer.clear();
+
+    CqlSession session = storage.session.session;
+    if (session == null) session = globalSession;
+
+    List<String> toTruncate = new ArrayList<>(SEARCH_TABLES);
+    toTruncate.add(TABLE_DEPENDENCY);
+    toTruncate.add(TABLE_SPAN);
+
+    for (String table : toTruncate) {
+      try {
+        session.execute("TRUNCATE " + storage.keyspace + "." + table);
+      } catch (InvalidQueryException e) {
+        assertThat(e).hasMessage("unconfigured table " + table);
+      }
+    }
+
+    blockWhileInFlight(storage);
   }
 
   @Override public void afterAll(ExtensionContext context) {
-    if (container != null) {
-      LOGGER.info("Stopping docker image " + image);
-      container.stop();
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
     }
+    if (globalSession != null) globalSession.close();
   }
 
   static final class CassandraContainer extends GenericContainer<CassandraContainer> {
@@ -82,29 +152,53 @@ public class CassandraStorageExtension implements BeforeAllCallback, AfterAllCal
     }
 
     @Override protected void waitUntilContainerStarted() {
-      Unreliables.retryUntilSuccess(2, TimeUnit.MINUTES, () -> {
-        if (!isRunning()) {
-          throw new ContainerLaunchException("Container failed to start");
-        }
+      Unreliables.retryUntilSuccess(120, TimeUnit.SECONDS, () -> {
+        if (!isRunning()) throw new ContainerLaunchException("Container failed to start");
 
-        InetSocketAddress address =
-          new InetSocketAddress(getContainerIpAddress(), getMappedPort(9042));
-
-        try (Cluster cluster = getCluster(address); Session session = cluster.newSession()) {
+        String contactPoint = getContainerIpAddress() + ":" + getMappedPort(9042);
+        try (CqlSession session = tryToInitializeSession(contactPoint)) {
           session.execute("SELECT now() FROM system.local");
-          logger().info("Obtained a connection to container ({})", cluster.getClusterName());
+          logger().info("Obtained a connection to container ({})", contactPoint);
           return null; // unused value
         }
       });
     }
   }
 
-  static Cluster getCluster(InetSocketAddress contactPoint) {
-    return Cluster.builder()
-      .withoutJMXReporting()
-      .addContactPointsWithPorts(contactPoint)
-      .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
-      .withPoolingOptions(new PoolingOptions().setMaxConnectionsPerHost(HostDistance.LOCAL, 1))
-      .build();
+  static void blockWhileInFlight(CassandraStorage storage) {
+    CqlSession session = storage.session.get();
+    // Now, block until writes complete, notably so we can read them.
+    boolean wasInFlight = false;
+    while (true) {
+      if (!poolInFlight(session)) {
+        if (wasInFlight) sleep(100); // give a little more to avoid flakey tests
+        return;
+      }
+      wasInFlight = true;
+      sleep(100);
+    }
+  }
+
+  static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+
+  // Use metrics to wait for in-flight requests to settle per
+  // https://groups.google.com/a/lists.datastax.com/g/java-driver-user/c/5um_yGNynow/m/cInH5I5jBgAJ
+  static boolean poolInFlight(CqlSession session) {
+    Collection<Node> nodes = session.getMetadata().getNodes().values();
+    Optional<Metrics> metrics = session.getMetrics();
+    for (Node node : nodes) {
+      int inFlight = metrics.flatMap(m -> m.getNodeMetric(node, DefaultNodeMetric.IN_FLIGHT))
+        .map(m -> ((Gauge<Integer>) m).getValue())
+        .orElse(0);
+      if (inFlight > 0) return true;
+    }
+    return false;
   }
 }

--- a/cassandra3/src/test/resources/log4j.properties
+++ b/cassandra3/src/test/resources/log4j.properties
@@ -1,3 +1,4 @@
+# Set everything to be logged to the console
 log4j.rootCategory=WARN, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
@@ -11,9 +12,17 @@ log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
 # SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
 log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
-
 log4j.logger.zipkin2=WARN
-log4j.logger.org.testcontainers=INFO
-log4j.logger.org.apache.http=WARN
-log4j.logger.com.github.dockerjava=WARN
-log4j.logger.org.zeroturnaround.exec=WARN
+# our tests check for schema portability, so hush lack of schema logs
+log4j.logger.zipkin2.storage.cassandra.Schema=off
+# don't spam about SASI
+log4j.logger.com.datastax.oss.driver.internal.core.cql.CqlRequestHandler=error
+# ignore connection close errors when polling for cassandra to start
+log4j.logger.com.datastax.oss.driver.internal.core.control.ControlConnection=error
+# ignore warnings about too many sessions
+log4j.logger.com.datastax.oss.driver.internal.core.session.DefaultSession=error
+# stop huge spam
+log4j.logger.org.testcontainers.dockerclient=off
+# Schema install takes a while. Log basic information to prevent CI from thinking things are hung
+log4j.logger.zipkin2.storage.cassandra.CassandraStorageExtension=info
+DeduplicatingInsertTest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /install
 COPY --from=scratch /code /code
 
 # This will either be "master" or a real version ex. "2.4.5"
-ARG release_version
+ARG release_version=master
 ENV RELEASE_VERSION=${release_version}
 COPY docker/bin/install.sh /tmp/
 RUN /tmp/install.sh && rm /tmp/install.sh

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -28,14 +28,14 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <okhttp.version>4.4.0</okhttp.version>
+    <okhttp.version>4.9.0</okhttp.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch-spark-20_${scala.binary.version}</artifactId>
-      <version>7.6.1</version>
+      <version>7.9.2</version>
     </dependency>
 
     <dependency>

--- a/elasticsearch/src/test/java/zipkin2/elasticsearch/ITElasticsearchV6Dependencies.java
+++ b/elasticsearch/src/test/java/zipkin2/elasticsearch/ITElasticsearchV6Dependencies.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ITElasticsearchV6Dependencies extends ITElasticsearchDependencies {
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch6:2.21.7");
+    "openzipkin/zipkin-elasticsearch6:2.22.0");
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/elasticsearch/src/test/java/zipkin2/elasticsearch/ITElasticsearchV7Dependencies.java
+++ b/elasticsearch/src/test/java/zipkin2/elasticsearch/ITElasticsearchV7Dependencies.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ITElasticsearchV7Dependencies extends ITElasticsearchDependencies {
   @RegisterExtension ElasticsearchStorageExtension backend = new ElasticsearchStorageExtension(
-    "openzipkin/zipkin-elasticsearch7:2.21.7");
+    "openzipkin/zipkin-elasticsearch7:2.22.0");
 
   @Override ElasticsearchStorageExtension backend() {
     return backend;

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -149,25 +149,6 @@
                   </excludes>
                 </filter>
               </filters>
-              <!--
-                com.datastax.driver.core.Cluster fails to initialize (because of its check for 16.01)
-                See https://stackoverflow.com/questions/36877897/detected-guava-issue-1635-which-indicates-that-a-version-of-guava-less-than-16
-                TODO: When cassandra-driver-core 4.x is out, revisit this as it no longer uses guava
-              -->
-              <relocations>
-                <relocation>
-                  <pattern>com.google.common</pattern>
-                  <shadedPattern>shaded.com.google.common</shadedPattern>
-                  <includes>
-                    <include>com.google.common.**</include>
-                  </includes>
-                  <excludes>
-                    <exclude>com.google.common.base.Optional</exclude>
-                    <exclude>com.google.common.base.Absent</exclude>
-                    <exclude>com.google.common.base.Present</exclude>
-                  </excludes>
-                </relocation>
-              </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>

--- a/main/src/main/java/zipkin2/dependencies/ZipkinDependenciesJob.java
+++ b/main/src/main/java/zipkin2/dependencies/ZipkinDependenciesJob.java
@@ -21,7 +21,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.LinkedHashMap;
 import java.util.TimeZone;
-
 import zipkin2.dependencies.cassandra.CassandraDependenciesJob;
 import zipkin2.dependencies.elasticsearch.ElasticsearchDependenciesJob;
 import zipkin2.dependencies.mysql.MySQLDependenciesJob;

--- a/mysql/pom.xml
+++ b/mysql/pom.xml
@@ -33,7 +33,7 @@
 
          MariaDB has a friendlier license, LGPL, which is less scary in audits.
     -->
-    <mariadb-java-client.version>2.5.4</mariadb-java-client.version>
+    <mariadb-java-client.version>2.7.0</mariadb-java-client.version>
   </properties>
 
   <dependencies>

--- a/mysql/src/main/java/zipkin2/dependencies/mysql/MySQLDependenciesJob.java
+++ b/mysql/src/main/java/zipkin2/dependencies/mysql/MySQLDependenciesJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,17 +13,6 @@
  */
 package zipkin2.dependencies.mysql;
 
-import org.apache.spark.SparkConf;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.Function;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SQLContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import scala.Tuple2;
-import zipkin2.DependencyLink;
-
-import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -35,6 +24,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+import zipkin2.DependencyLink;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static zipkin2.internal.DateUtil.midnightUTC;

--- a/mysql/src/test/java/zipkin2/storage/mysql/v1/ITMySQLDependencies.java
+++ b/mysql/src/test/java/zipkin2/storage/mysql/v1/ITMySQLDependencies.java
@@ -16,31 +16,59 @@ package zipkin2.storage.mysql.v1;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import zipkin2.Span;
 import zipkin2.dependencies.mysql.MySQLDependenciesJob;
-import zipkin2.storage.ITDependencies;
-import zipkin2.storage.StorageComponent;
 
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
+import static zipkin2.storage.ITDependencies.aggregateLinks;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ITMySQLDependencies extends ITDependencies<MySQLStorage> {
+class ITMySQLDependencies {
   @RegisterExtension MySQLStorageExtension backend = new MySQLStorageExtension(
-    "openzipkin/zipkin-mysql:2.21.7");
+    "openzipkin/zipkin-mysql:2.22.0");
 
-  @Override protected StorageComponent.Builder newStorageBuilder(TestInfo testInfo) {
+  MySQLStorage.Builder newStorageBuilder() {
     return backend.computeStorageBuilder();
   }
 
-  @Override public void clear() {
-    storage.clear();
+  @Nested
+  class ITDependencies extends zipkin2.storage.ITDependencies<MySQLStorage> {
+
+    @Override protected MySQLStorage.Builder newStorageBuilder(TestInfo testInfo) {
+      return ITMySQLDependencies.this.newStorageBuilder();
+    }
+
+    @Override public void clear() {
+      storage.clear();
+    }
+
+    @Override protected void processDependencies(List<Span> spans) throws Exception {
+      ITMySQLDependencies.this.processDependencies(storage, spans);
+    }
+  }
+
+  @Nested
+  class ITDependenciesHeavy extends zipkin2.storage.ITDependenciesHeavy<MySQLStorage> {
+
+    @Override protected MySQLStorage.Builder newStorageBuilder(TestInfo testInfo) {
+      return ITMySQLDependencies.this.newStorageBuilder();
+    }
+
+    @Override public void clear() {
+      storage.clear();
+    }
+
+    @Override protected void processDependencies(List<Span> spans) throws Exception {
+      ITMySQLDependencies.this.processDependencies(storage, spans);
+    }
   }
 
   /** This processes the job as if it were a batch. For each day we had traces, run the job again. */
-  @Override public void processDependencies(List<Span> spans) throws IOException {
+  void processDependencies(MySQLStorage storage, List<Span> spans) throws IOException {
     storage.spanConsumer().accept(spans).execute();
 
     // aggregate links in memory to determine which days they are in
@@ -49,10 +77,10 @@ class ITMySQLDependencies extends ITDependencies<MySQLStorage> {
     // process the job for each day of links.
     for (long day : days) {
       MySQLDependenciesJob.builder()
-        .user(backend.container.getUsername())
-        .password(backend.container.getPassword())
+        .user("zipkin")
+        .password("zipkin")
         .port(backend.container.getMappedPort(MYSQL_PORT))
-        .db(backend.container.getDatabaseName())
+        .db("zipkin")
         .day(day).build().run();
     }
   }

--- a/mysql/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
+++ b/mysql/src/test/java/zipkin2/storage/mysql/v1/MySQLStorageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.CheckResult;
 
-import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class MySQLStorageExtension implements BeforeAllCallback, AfterAllCallback {
@@ -37,17 +36,24 @@ class MySQLStorageExtension implements BeforeAllCallback, AfterAllCallback {
   }
 
   @Override public void beforeAll(ExtensionContext context) {
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
+    }
+
     if (!"true".equals(System.getProperty("docker.skip"))) {
       try {
         container = new ZipkinMySQLContainer(image);
         container.start();
-        LOGGER.info("Starting docker image " + container.getDockerImageName());
-      } catch (Exception e) {
-        LOGGER.warn("Couldn't start docker image " + container.getDockerImageName(), e);
+        LOGGER.info("Starting docker image " + image);
+      } catch (RuntimeException e) {
+        LOGGER.warn("Couldn't start docker image " + image + ": " + e.getMessage(), e);
       }
     } else {
-      LOGGER.info("Skipping startup of docker");
+      LOGGER.info("Skipping startup of docker " + image);
     }
+
+    assumeTrue(container != null, "Docker not available");
 
     try (MySQLStorage result = computeStorageBuilder().build()) {
       CheckResult check = result.check();
@@ -57,38 +63,26 @@ class MySQLStorageExtension implements BeforeAllCallback, AfterAllCallback {
   }
 
   @Override public void afterAll(ExtensionContext context) {
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
+    }
     if (container != null) container.stop();
   }
 
   MySQLStorage.Builder computeStorageBuilder() {
-    MariaDbDataSource dataSource;
-    try {
-      if (container != null) {
-        dataSource = container.getDataSource();
-      } else {
-        dataSource = new MariaDbDataSource();
-        dataSource.setUser(System.getenv("MYSQL_USER"));
-        assumeTrue("Minimally, the environment variable MYSQL_USER must be set",
-          dataSource.getUser() != null);
+    final MariaDbDataSource dataSource;
 
-        dataSource.setServerName(envOr("MYSQL_HOST", "localhost"));
-        dataSource.setPort(envOr("MYSQL_TCP_PORT", 3306));
-        dataSource.setDatabaseName(envOr("MYSQL_DB", "zipkin"));
-        dataSource.setPassword(envOr("MYSQL_PASS", ""));
-      }
+    try {
+      assumeTrue(container != null, "Docker not available");
+      dataSource = container.getDataSource();
       dataSource.setProperties("autoReconnect=true&useUnicode=yes&characterEncoding=UTF-8");
     } catch (SQLException e) {
       throw new AssertionError(e);
     }
 
-    return new MySQLStorage.Builder().datasource(dataSource).executor(Runnable::run);
-  }
-
-  static int envOr(String key, int fallback) {
-    return System.getenv(key) != null ? Integer.parseInt(System.getenv(key)) : fallback;
-  }
-
-  static String envOr(String key, String fallback) {
-    return System.getenv(key) != null ? System.getenv(key) : fallback;
+    return new MySQLStorage.Builder()
+      .datasource(dataSource)
+      .executor(Runnable::run);
   }
 }

--- a/mysql/src/test/resources/drop_zipkin_tables.sql
+++ b/mysql/src/test/resources/drop_zipkin_tables.sql
@@ -1,0 +1,8 @@
+SET FOREIGN_KEY_CHECKS = 0;
+SET @tables = NULL;
+SELECT GROUP_CONCAT(table_schema, '.', table_name) INTO @tables FROM information_schema.tables WHERE table_schema = 'zipkin';
+SET @tables = CONCAT('DROP TABLE ', @tables);
+PREPARE stmt FROM @tables;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+SET FOREIGN_KEY_CHECKS = 1;

--- a/pom.xml
+++ b/pom.xml
@@ -45,31 +45,26 @@
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>2.4.7</spark.version>
 
-    <zipkin.version>2.21.7</zipkin.version>
-    <armeria.version>0.99.9</armeria.version>
-    <jackson.version>2.11.2</jackson.version>
+    <zipkin.version>2.22.0</zipkin.version>
+    <armeria.version>1.2.0</armeria.version>
+    <jackson.version>2.11.3</jackson.version>
 
-    <!-- Can't upgrade to connector 2.5 until Zipkin upgrades to DataStax driver v4 -->
-    <spark-cassandra-connector.version>2.4.3</spark-cassandra-connector.version>
-    <!-- connector uses an old version of the driver -->
-    <cassandra-driver-core.version>3.10.2</cassandra-driver-core.version>
+    <spark-cassandra-connector.version>2.5.1</spark-cassandra-connector.version>
+    <java-driver.version>4.9.0</java-driver.version>
 
-    <junit.version>4.13</junit.version>
+    <junit.version>4.13.1</junit.version>
     <junit-jupiter.version>5.7.0</junit-jupiter.version>
     <assertj.version>3.17.2</assertj.version>
-    <testcontainers.version>1.14.3</testcontainers.version>
+    <testcontainers.version>1.15.0-rc2</testcontainers.version>
 
     <animal-sniffer-maven-plugin.version>1.19</animal-sniffer-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
-    <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-    <!-- 3.0.0-M5 breaks the build: https://github.com/openzipkin/zipkin/issues/3159 -->
-    <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
-    <maven-invoker-plugin.version>3.2.1</maven-invoker-plugin.version>
     <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
@@ -148,18 +143,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.datastax.cassandra</groupId>
-        <artifactId>cassandra-driver-core</artifactId>
-        <version>${cassandra-driver-core.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.datastax.cassandra</groupId>
-        <artifactId>cassandra-driver-mapping</artifactId>
-        <version>${cassandra-driver-core.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-dependencies-mysql</artifactId>
         <version>${project.version}</version>
@@ -187,6 +170,14 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-bom</artifactId>
+        <version>${java-driver.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -296,21 +287,29 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
+        <configuration>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
       </plugin>
 
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
+        <configuration>
+          <!-- Try to prevent flakes in CI -->
+          <reuseForks>false</reuseForks>
+          <!-- workaround to SUREFIRE-1831 -->
+          <useModulePath>false</useModulePath>
+          <!-- Ensure scope leak cause ends up in the console -->
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
         <executions>
           <execution>
             <id>integration-test</id>
+            <phase>verify</phase>
             <goals>
               <goal>integration-test</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>verify</id>
-            <goals>
               <goal>verify</goal>
             </goals>
           </execution>


### PR DESCRIPTION
Most of the bigger change is due to our integration tests being split
into heavy or not. There are other Docker related things that drifted
and so work differently now. Each of the docker extensions is almost
exactly copy/paste from openzipkin/zipkin.