### PR TITLE
Fix Elasticsearch 7.x/OpenSearch 1.1 span processing

### DIFF
--- a/docker/periodic/daily/zipkin-dependencies-yesterday
+++ b/docker/periodic/daily/zipkin-dependencies-yesterday
@@ -13,4 +13,5 @@
 # the License.
 #
 
+cd /zipkin-dependencies
 start-zipkin-dependencies `date -ud yesterday +%F`

--- a/docker/periodic/hourly/zipkin-dependencies-today
+++ b/docker/periodic/hourly/zipkin-dependencies-today
@@ -13,4 +13,5 @@
 # the License.
 #
 
+cd /zipkin-dependencies
 start-zipkin-dependencies

--- a/elasticsearch/src/main/java/zipkin2/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
+++ b/elasticsearch/src/main/java/zipkin2/dependencies/elasticsearch/ElasticsearchDependenciesJob.java
@@ -208,6 +208,8 @@ public final class ElasticsearchDependenciesJob {
             dependencyLinkResource,
             Collections.singletonMap("es.mapping.id", "id")); // allows overwriting the link
       }
+    } catch (Exception e) {
+      log.warn("Failed to process spans from {}", spanResource, e);
     } finally {
       sc.stop();
     }


### PR DESCRIPTION
PR to address <https://github.com/openzipkin/zipkin-dependencies/issues/202>:
- catch failed process span runs and log warning message
- fix crond scripts as proposed in <https://github.com/openzipkin/zipkin-dependencies/issues/192>