### PR TITLE
build: fixes bugs in both jar and docker packaging

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,9 @@ ENV VERSION=$version
 ENV MAVEN_PROJECT_BASEDIR=/code
 RUN /code/build-bin/maven/maven_build_or_unjar io.zipkin.dependencies zipkin-dependencies ${VERSION}
 
-FROM ghcr.io/openzipkin/java:11.0.21_p9-jre as zipkin-dependencies
+# Try -jre again once Spark dependencies are up to date. Spark 3.0 uses old Hadoop in the
+# Elasticsearch driver which needs com.sun.security.auth.module.UnixLoginModule.
+FROM ghcr.io/openzipkin/java:11.0.21_p9 as zipkin-dependencies
 LABEL org.opencontainers.image.description="Zipkin Dependencies Aggregator on OpenJDK and Alpine Linux"
 LABEL org.opencontainers.image.source=https://github.com/openzipkin/zipkin-dependencies
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -124,7 +124,7 @@
                 </filter>
                 <filter>
                   <!-- org.elasticsearch.spark.sql.SparkSQLCompatibilityLevel -->
-                  <artifact>org.elasticsearch:elasticsearch-spark-20_${scala.binary.version}
+                  <artifact>org.elasticsearch:elasticsearch-spark-30_${scala.binary.version}
                   </artifact>
                   <includes>
                     <include>**</include>


### PR DESCRIPTION
* due to use of ancient hadoop which uses sun. packages, we have to use a full JRE. We can revisit once off that.
* when we updated from spark 2.x to 3.x we missed a maven shade expression which led to classes not found in Elasticsearch (others ok)