### PR TITLE
example: migrates in example from zipkin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can also start Zipkin Dependencies via [Docker](https://github.com/openzipki
 $ docker run --env STORAGE_TYPE=cassandra3 --env CASSANDRA_CONTACT_POINTS=host1,host2 openzipkin/zipkin-dependencies
 ```
 
+For a more complete example, take a look at the [docker-compose example](docker/examples/README.md).
+
 ## Usage
 
 By default, this job parses all traces since midnight UTC. You can parse traces for a different day

--- a/docker/examples/.dockerignore
+++ b/docker/examples/.dockerignore
@@ -1,0 +1,2 @@
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+**/.*

--- a/docker/examples/README.md
+++ b/docker/examples/README.md
@@ -1,0 +1,37 @@
+# Zipkin Dependencies Docker Examples
+
+This project is configured to run docker containers using
+[docker-compose](https://docs.docker.com/compose/). Note that the default
+configuration requires docker-compose 2.4+.
+
+To start the default docker-compose configuration, run:
+
+```bash
+# choose a specific tag, 'latest' for the last released or 'master' for last built.
+$ export TAG=latest
+# choose from cassandra3, elasticsearch or mysql
+$ STORAGE_TYPE=elasticsearch
+# start the example setup
+$ docker-compose -f docker-compose.yml -f docker-compose-${STORAGE_TYPE}.yml up
+```
+
+This starts zipkin, the corresponding storage and makes an example request.
+After that, it runs the dependencies job on-demand.
+
+You can then use the following two services:
+* Zipkin's UI is reachable at http://localhost:9411/zipkin/dependency
+* An example traced service at http://localhost:8081
+
+If you make more requests to the example traced service, you can run the
+dependencies job in another tab like so, and that will overwrite the day's
+data:
+
+```bash
+$ docker-compose -f docker-compose.yml -f docker-compose-${STORAGE_TYPE}.yml start dependencies
+```
+
+Finally, when done, CTRL-C and remove the example setup via `docker-compose down` like so:
+
+```bash
+$ docker-compose -f docker-compose.yml -f docker-compose-${STORAGE_TYPE}.yml down
+```

--- a/docker/examples/docker-compose-cassandra3.yml
+++ b/docker/examples/docker-compose-cassandra3.yml
@@ -1,0 +1,58 @@
+#
+# Copyright 2016-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to run the
+# zipkin-cassandra container instead of the zipkin-mysql container.
+
+version: '2.4'
+
+services:
+  storage:
+    image: ghcr.io/openzipkin/zipkin-cassandra:${TAG:-latest}
+    # Uncomment to use DSE instead (minimum version 5.1)
+    # image: datastax/dse-server:5.1.20
+    # environment:
+    #  - DS_LICENSE=accept
+    container_name: cassandra
+    # Uncomment to expose the storage port for testing
+    # ports:
+    #   - 9042:9042
+
+  # Use Cassandra instead of in-memory storage
+  zipkin:
+    extends:
+      file: docker-compose.yml
+      service: zipkin
+    environment:
+      - STORAGE_TYPE=cassandra3
+      # When using the test docker image, or have schema pre-installed, you don't need to ensure it
+      - CASSANDRA_ENSURE_SCHEMA=false
+      # When overriding this value, note the minimum supported version is 3.11.3
+      - CASSANDRA_CONTACT_POINTS=cassandra
+      # Uncomment to configure authentication
+      # - CASSANDRA_USERNAME=cassandra
+      # - CASSANDRA_PASSWORD=cassandra
+    # Uncomment to enable request logging (TRACE shows query values)
+    # command: --logging.level.com.datastax.oss.driver.internal.core.tracker.RequestLogger=TRACE
+
+  dependencies:
+    extends:
+      file: docker-compose.yml
+      service: dependencies
+    environment:
+      - STORAGE_TYPE=${STORAGE_TYPE:-cassandra3}
+      - CASSANDRA_CONTACT_POINTS=cassandra

--- a/docker/examples/docker-compose-elasticsearch.yml
+++ b/docker/examples/docker-compose-elasticsearch.yml
@@ -1,0 +1,49 @@
+#
+# Copyright 2016-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to run the
+# zipkin-elasticsearch container instead of the zipkin-mysql container.
+
+version: '2.4'
+
+services:
+  storage:
+    image: ghcr.io/openzipkin/zipkin-elasticsearch8:${TAG:-latest}
+    container_name: elasticsearch
+    # Uncomment to expose the storage port for testing
+    # ports:
+    #   - 9200:9200
+
+  # Use Elasticsearch instead of in-memory storage
+  zipkin:
+    extends:
+      file: docker-compose.yml
+      service: zipkin
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      # Point the zipkin at the storage backend
+      - ES_HOSTS=elasticsearch:9200
+      # Uncomment to see requests to and from elasticsearch
+      # - ES_HTTP_LOGGING=BODY
+
+  dependencies:
+    extends:
+      file: docker-compose.yml
+      service: dependencies
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      - ES_HOSTS=elasticsearch

--- a/docker/examples/docker-compose-mysql.yml
+++ b/docker/examples/docker-compose-mysql.yml
@@ -1,0 +1,54 @@
+#
+# Copyright 2016-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# This runs the zipkin and zipkin-mysql containers, using docker-compose's
+# default networking to wire the containers together.
+#
+# Note that this file is meant for learning Zipkin, not production deployments.
+
+version: '2.4'
+
+services:
+  storage:
+    image: ghcr.io/openzipkin/zipkin-mysql:${TAG:-latest}
+    container_name: mysql
+    # Uncomment to expose the storage port for testing
+    # ports:
+    #   - 3306:3306
+
+  # Use MySQL instead of in-memory storage
+  zipkin:
+    extends:
+      file: docker-compose.yml
+      service: zipkin
+    environment:
+      - STORAGE_TYPE=mysql
+      - MYSQL_HOST=storage
+      # Add the baked-in username and password for the zipkin-mysql image
+      - MYSQL_USER=zipkin
+      - MYSQL_PASS=zipkin
+
+  dependencies:
+    extends:
+      file: docker-compose.yml
+      service: dependencies
+    environment:
+      - STORAGE_TYPE=mysql
+      - MYSQL_HOST=storage
+      # Add the baked-in username and password for the zipkin-mysql image
+      - MYSQL_USER=zipkin
+      - MYSQL_PASS=zipkin

--- a/docker/examples/docker-compose.yml
+++ b/docker/examples/docker-compose.yml
@@ -1,0 +1,87 @@
+#
+# Copyright 2016-2023 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# This runs the zipkin slim container, using docker-compose's default networking
+# to wire other containers together.
+#
+# Note that this file is meant for learning Zipkin, not production deployments.
+
+version: '2.4'
+
+services:
+  # The zipkin process services the UI, and also exposes a POST endpoint that
+  # instrumentation can send trace data to.
+  zipkin:
+    image: ghcr.io/openzipkin/zipkin:2
+    container_name: zipkin
+    # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
+    environment:
+      - STORAGE_TYPE=mem
+    ports:
+      # Port used for the Zipkin UI and HTTP Api
+      - 9411:9411
+    # Uncomment to enable debug logging
+    # command: --logging.level.zipkin2=DEBUG
+    depends_on:
+      storage:
+        condition: service_healthy
+
+  # Generate traffic by hitting http://localhost:8081
+  frontend:
+    container_name: frontend
+    image: ghcr.io/openzipkin/brave-example:${PROJECT:-armeria}
+    entrypoint: start-frontend
+    ports:
+      - 8081:8081
+    depends_on:
+      backend:
+        condition: service_healthy
+      zipkin:
+        condition: service_started
+  # Serves the /api endpoint the frontend uses
+  backend:
+    container_name: backend
+    image: ghcr.io/openzipkin/brave-example:armeria
+    entrypoint: start-backend
+    depends_on:
+      zipkin:
+        condition: service_started
+
+  get-frontend:
+    container_name: get-frontend
+    image: ghcr.io/openzipkin/brave-example:armeria
+    entrypoint: wget -qO- --tries=5 http://frontend:8081
+    depends_on:
+      frontend:
+        condition: service_healthy
+      zipkin:
+        condition: service_started
+
+  # Run dependencies job on-demand.
+  dependencies:
+    image: ghcr.io/openzipkin/zipkin-dependencies:${TAG:-latest}
+    container_name: dependencies
+    entrypoint: start-zipkin-dependencies
+      # environment:
+      # Uncomment to see dependency processing logs
+      # - ZIPKIN_LOG_LEVEL=DEBUG
+    # Uncomment to adjust memory used by the dependencies job
+    # - JAVA_OPTS=-verbose:gc -Xms1G -Xmx1G
+    depends_on:
+      get-frontend:
+        condition: service_started
+


### PR DESCRIPTION
Zipkin has a complete example of using the dependencies job, but that wasn't copied here. This moves it so that people can do ad-hoc testing and know if for example upgrading spark works or not.