### PR TITLE
docker: works around statx issues by avoiding coreutils

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,8 +43,9 @@ FROM ghcr.io/openzipkin/java:11.0.22_p7 as zipkin-dependencies
 LABEL org.opencontainers.image.description="Zipkin Dependencies Aggregator on OpenJDK and Alpine Linux"
 LABEL org.opencontainers.image.source=https://github.com/openzipkin/zipkin-dependencies
 
-# Adds coreutils to allow date formatting of 'yesterday'
-RUN apk add --no-cache coreutils
+# Adds dateutils to allow date formatting. Don't use coreutils until below:
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/16002
+RUN apk add --no-cache dateutils
 
 # Create custom user and ensure the process doesn't run as root
 ARG USER=zipkin-dependencies

--- a/docker/periodic/daily/zipkin-dependencies-yesterday
+++ b/docker/periodic/daily/zipkin-dependencies-yesterday
@@ -5,4 +5,4 @@
 #
 
 cd /zipkin-dependencies
-start-zipkin-dependencies `date -ud yesterday +%F`
+start-zipkin-dependencies `dateadd now -1d | dconv -f '%Y-%m-%d'`


### PR DESCRIPTION
I noticed a confusing glitch and raised an upstream bug. It may be limited to aarch64, not sure.

```bash
$ docker run --platform=linux/arm64 --rm -it --entrypoint=/bin/sh ghcr.io/openzipkin/java:17.0.10_p7
/java # apk add --no-cache coreutils
--snip--
/java # cat /etc/profile
Error relocating /bin/cat: statx: symbol not found
```
https://gitlab.alpinelinux.org/alpine/aports/-/issues/16002
