### PR TITLE
Adds SECURITY.md and scanning workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,56 @@
+---
+name: security
+
+# We don't scan documentation-only commits.
+on:  # yamllint disable-line rule:truthy
+  push:  # non-tagged pushes to master
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+    paths-ignore:
+      - '**/*.md'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+  pull_request:  # pull requests targeted at the master branch.
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+
+jobs:
+  security:
+    name: security
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    # skip commits made by the release plugin
+    if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        name: Cache Trivy Database
+        with:
+          path: .trivy
+          key: ${{ runner.os }}-trivy
+          restore-keys: ${{ runner.os }}-trivy
+      - name: Run Trivy vulnerability and secret scanner
+        uses: aquasecurity/trivy-action@master
+        id: trivy
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'  # scan the entire repository
+          scanners: vuln,secret
+          exit-code: '1'
+          severity: HIGH,CRITICAL
+          output: trivy-report.md
+          cache-dir: .trivy
+      - name: Set Summary
+        shell: bash
+        if: ${{ failure() && steps.trivy.conclusion == 'failure' }}
+        # Add the Trivy report to the summary
+        #
+        # Note: This will cause a workflow error if trivy-report.md > the step
+        # limit 1MiB. If this was due to too many CVEs, consider fixing them ;)
+        run: cat trivy-report.md >> $GITHUB_STEP_SUMMARY

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,12 @@
 
 This repo uses semantic versions. Please keep this in mind when choosing version numbers.
 
+1. **Verify all dependencies are up-to-date**
+
+   Before you start a release, make sure all dependencies are up-to-date, or are documented why not.
+   Pay special attention to the [security workflow](.github/workflows/security.yml), which should
+   run clean.
+
 1. **Alert others you are releasing**
 
    There should be no commits made to master while the release is in progress (about 10 minutes). Before you start

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# OpenZipkin Security Process
+
+This document outlines the process for handling security concerns in OpenZipkin projects.
+
+Any vulnerability or misconfiguration detected in our [security workflow](.github/workflows/security.yml)
+should be addressed as a normal pull request.
+
+OpenZipkin is a volunteer community and does not have a dedicated security team. There may be
+periods where no volunteer is able to address a security concern. There is no SLA or warranty
+offered by volunteers. If you are a security researcher, please consider this before escalating.
+
+For security concerns that are sensitive or otherwise outside the scope of public issues, please
+contact zipkin-admin@googlegroups.com.


### PR DESCRIPTION
This adds SECURITY.md and a scanning workflow, using Trivy. In particular, this clarifies what we use to scan for vulnerabilities (Trivy, not anything else), and the only channel likely to be responded to on a significant issue (zipkin-admin email, not advisories as people ignored them).

This is the same approach as approved and merged in https://github.com/openzipkin/zipkin-reporter-java/pull/267