### PR TITLE
temporarily ignores snapshots so that we can release

### DIFF
--- a/build-bin/deploy
+++ b/build-bin/deploy
@@ -10,6 +10,7 @@ if [ "${version}" = "master" ]; then
   version=$(sed -En 's/.*<version>(.*)<\/version>.*/\1/p' pom.xml| head -1)
 fi
 
-build-bin/maven/maven_deploy
+# TODO: remove -DignoreSnapshots=true after ES 8.14.0 is released
+build-bin/maven/maven_deploy -DignoreSnapshots=true
 export RELEASE_FROM_MAVEN_BUILD=true
 build-bin/docker_push ${version}


### PR DESCRIPTION
this project is not used in any way except an all-jar or a docker image, so we can release even if not proper, by temporarily ignoring snapshots. This is better than awaiting ES 8.14 which we don't know when will be released.